### PR TITLE
fix: ドメインオブジェクトからorderNoを削除

### DIFF
--- a/backend/src/main/java/com/example/keirekipro/domain/model/resume/Career.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/resume/Career.java
@@ -25,8 +25,8 @@ public class Career extends Entity {
     /**
      * 新規構築用のコンストラクタ
      */
-    private Career(int orderNo, String companyName, Period period) {
-        super(orderNo);
+    private Career(String companyName, Period period) {
+        super();
         this.companyName = companyName;
         this.period = period;
     }
@@ -34,8 +34,8 @@ public class Career extends Entity {
     /**
      * 再構築用のコンストラクタ
      */
-    private Career(UUID id, int orderNo, String companyName, Period period) {
-        super(id, orderNo);
+    private Career(UUID id, String companyName, Period period) {
+        super(id);
         this.companyName = companyName;
         this.period = period;
     }
@@ -43,26 +43,24 @@ public class Career extends Entity {
     /**
      * 新規構築用のファクトリーメソッド
      *
-     * @param orderNo     並び順
      * @param companyName 会社名
      * @param period      期間
      * @return 職歴エンティティ
      */
-    public static Career create(int orderNo, String companyName, Period period) {
-        return new Career(orderNo, companyName, period);
+    public static Career create(String companyName, Period period) {
+        return new Career(companyName, period);
     }
 
     /**
      * 再構築用のファクトリーメソッド
      *
      * @param id          識別子
-     * @param orderNo     並び順
      * @param companyName 会社名
      * @param period      期間
      * @return 職歴エンティティ
      */
-    public static Career reconstruct(UUID id, int orderNo, String companyName, Period period) {
-        return new Career(id, orderNo, companyName, period);
+    public static Career reconstruct(UUID id, String companyName, Period period) {
+        return new Career(id, companyName, period);
     }
 
     /**
@@ -72,7 +70,7 @@ public class Career extends Entity {
      * @return 変更後の職歴エンティティ
      */
     public Career changeCompanyName(String companyName) {
-        return new Career(this.id, this.orderNo, companyName, this.period);
+        return new Career(this.id, companyName, this.period);
     }
 
     /**
@@ -82,6 +80,6 @@ public class Career extends Entity {
      * @return 変更後の職歴エンティティ
      */
     public Career changePeriod(Period period) {
-        return new Career(this.id, this.orderNo, this.companyName, period);
+        return new Career(this.id, this.companyName, period);
     }
 }

--- a/backend/src/main/java/com/example/keirekipro/domain/model/resume/Certification.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/resume/Certification.java
@@ -26,8 +26,8 @@ public class Certification extends Entity {
     /**
      * 新規構築用のコンストラクタ
      */
-    private Certification(int orderNo, String name, YearMonth date) {
-        super(orderNo);
+    private Certification(String name, YearMonth date) {
+        super();
         this.name = name;
         this.date = date;
     }
@@ -35,8 +35,8 @@ public class Certification extends Entity {
     /**
      * 再構築用のコンストラクタ
      */
-    private Certification(UUID id, int orderNo, String name, YearMonth date) {
-        super(id, orderNo);
+    private Certification(UUID id, String name, YearMonth date) {
+        super(id);
         this.name = name;
         this.date = date;
     }
@@ -44,26 +44,24 @@ public class Certification extends Entity {
     /**
      * 新規構築用のファクトリーメソッド
      *
-     * @param orderNo 並び順
-     * @param name    会社名
-     * @param date    取得年月
+     * @param name 会社名
+     * @param date 取得年月
      * @return 資格エンティティ
      */
-    public static Certification create(int orderNo, String name, YearMonth date) {
-        return new Certification(orderNo, name, date);
+    public static Certification create(String name, YearMonth date) {
+        return new Certification(name, date);
     }
 
     /**
      * 再構築用のファクトリーメソッド
      *
-     * @param id      識別子
-     * @param orderNo 並び順
-     * @param name    会社名
-     * @param date    取得年月
+     * @param id   識別子
+     * @param name 会社名
+     * @param date 取得年月
      * @return 資格エンティティ
      */
-    public static Certification reconstruct(UUID id, int orderNo, String name, YearMonth date) {
-        return new Certification(id, orderNo, name, date);
+    public static Certification reconstruct(UUID id, String name, YearMonth date) {
+        return new Certification(id, name, date);
     }
 
     /**
@@ -73,7 +71,7 @@ public class Certification extends Entity {
      * @return 変更後の資格エンティティ
      */
     public Certification changeName(String name) {
-        return new Certification(this.id, this.orderNo, name, this.date);
+        return new Certification(this.id, name, this.date);
     }
 
     /**
@@ -83,6 +81,6 @@ public class Certification extends Entity {
      * @return 変更後の資格エンティティ
      */
     public Certification changeDate(YearMonth date) {
-        return new Certification(this.id, this.orderNo, this.name, date);
+        return new Certification(this.id, this.name, date);
     }
 }

--- a/backend/src/main/java/com/example/keirekipro/domain/model/resume/Portfolio.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/resume/Portfolio.java
@@ -35,8 +35,8 @@ public class Portfolio extends Entity {
     /**
      * 新規構築用のコンストラクタ
      */
-    private Portfolio(int orderNo, String name, String overview, String techStack, Link link) {
-        super(orderNo);
+    private Portfolio(String name, String overview, String techStack, Link link) {
+        super();
         this.name = name;
         this.overview = overview;
         this.techStack = techStack;
@@ -46,8 +46,8 @@ public class Portfolio extends Entity {
     /**
      * 再構築用のコンストラクタ
      */
-    private Portfolio(UUID id, int orderNo, String name, String overview, String techStack, Link link) {
-        super(id, orderNo);
+    private Portfolio(UUID id, String name, String overview, String techStack, Link link) {
+        super(id);
         this.name = name;
         this.overview = overview;
         this.techStack = techStack;
@@ -57,31 +57,29 @@ public class Portfolio extends Entity {
     /**
      * 新規構築用のファクトリーメソッド
      *
-     * @param orderNo   並び順
      * @param name      ポートフォリオ名
      * @param overview  ポートフォリオ概要
      * @param techStack 技術スタック
      * @param link      リンク
      * @return ポートフォリオエンティティ
      */
-    public static Portfolio create(int orderNo, String name, String overview, String techStack, Link link) {
-        return new Portfolio(orderNo, name, overview, techStack, link);
+    public static Portfolio create(String name, String overview, String techStack, Link link) {
+        return new Portfolio(name, overview, techStack, link);
     }
 
     /**
      * 再構築用のファクトリーメソッド
      *
      * @param id        識別子
-     * @param orderNo   並び順
      * @param name      ポートフォリオ名
      * @param overview  ポートフォリオ概要
      * @param techStack 技術スタック
      * @param link      リンク
      * @return ポートフォリオエンティティ
      */
-    public static Portfolio reconstruct(UUID id, int orderNo, String name, String overview, String techStack,
+    public static Portfolio reconstruct(UUID id, String name, String overview, String techStack,
             Link link) {
-        return new Portfolio(id, orderNo, name, overview, techStack, link);
+        return new Portfolio(id, name, overview, techStack, link);
     }
 
     /**
@@ -91,7 +89,7 @@ public class Portfolio extends Entity {
      * @return 変更後のポートフォリオエンティティ
      */
     public Portfolio changeName(String name) {
-        return new Portfolio(this.id, this.orderNo, name, this.overview, this.techStack, this.link);
+        return new Portfolio(this.id, name, this.overview, this.techStack, this.link);
     }
 
     /**
@@ -101,7 +99,7 @@ public class Portfolio extends Entity {
      * @return 変更後のポートフォリオエンティティ
      */
     public Portfolio changeOverview(String overview) {
-        return new Portfolio(this.id, this.orderNo, this.name, overview, this.techStack, this.link);
+        return new Portfolio(this.id, this.name, overview, this.techStack, this.link);
     }
 
     /**
@@ -111,7 +109,7 @@ public class Portfolio extends Entity {
      * @return 変更後のポートフォリオエンティティ
      */
     public Portfolio changeTechStack(String techStack) {
-        return new Portfolio(this.id, this.orderNo, this.name, this.overview, techStack, this.link);
+        return new Portfolio(this.id, this.name, this.overview, techStack, this.link);
     }
 
     /**
@@ -121,6 +119,6 @@ public class Portfolio extends Entity {
      * @return 変更後のポートフォリオエンティティ
      */
     public Portfolio changeLink(Link link) {
-        return new Portfolio(this.id, this.orderNo, this.name, this.overview, this.techStack, link);
+        return new Portfolio(this.id, this.name, this.overview, this.techStack, link);
     }
 }

--- a/backend/src/main/java/com/example/keirekipro/domain/model/resume/Project.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/resume/Project.java
@@ -61,10 +61,10 @@ public class Project extends Entity {
     /**
      * 新規構築用のコンストラクタ
      */
-    private Project(int orderNo, String companyName, Period period, String name, String overview, String teamComp,
+    private Project(String companyName, Period period, String name, String overview, String teamComp,
             String role,
             String achievement, Process process, TechStack techStack) {
-        super(orderNo);
+        super();
         this.companyName = companyName;
         this.period = period;
         this.name = name;
@@ -79,11 +79,11 @@ public class Project extends Entity {
     /**
      * 再構築用のコンストラクタ
      */
-    private Project(UUID id, int orderNo, String companyName, Period period, String name, String overview,
+    private Project(UUID id, String companyName, Period period, String name, String overview,
             String teamComp,
             String role,
             String achievement, Process process, TechStack techStack) {
-        super(id, orderNo);
+        super(id);
         this.companyName = companyName;
         this.period = period;
         this.name = name;
@@ -98,7 +98,6 @@ public class Project extends Entity {
     /**
      * 新規構築用のファクトリーメソッド
      *
-     * @param orderNo     並び順
      * @param companyName 会社名
      * @param period      期間
      * @param name        プロジェクト名
@@ -109,11 +108,11 @@ public class Project extends Entity {
      * @param process     作業工程
      * @return プロジェクトエンティティ
      */
-    public static Project create(int orderNo, String companyName, Period period, String name, String overview,
+    public static Project create(String companyName, Period period, String name, String overview,
             String teamComp,
             String role,
             String achievement, Process process, TechStack techStack) {
-        return new Project(orderNo, companyName, period, name, overview, teamComp, role, achievement, process,
+        return new Project(companyName, period, name, overview, teamComp, role, achievement, process,
                 techStack);
     }
 
@@ -121,7 +120,6 @@ public class Project extends Entity {
      * 再構築用のファクトリーメソッド
      *
      * @param id          識別子
-     * @param orderNo     並び順
      * @param companyName 会社名
      * @param period      期間
      * @param name        プロジェクト名
@@ -132,12 +130,12 @@ public class Project extends Entity {
      * @param process     作業工程
      * @return プロジェクトエンティティ
      */
-    public static Project reconstruct(UUID id, int orderNo, String companyName, Period period, String name,
+    public static Project reconstruct(UUID id, String companyName, Period period, String name,
             String overview,
             String teamComp,
             String role,
             String achievement, Process process, TechStack techStack) {
-        return new Project(id, orderNo, companyName, period, name, overview, teamComp, role, achievement, process,
+        return new Project(id, companyName, period, name, overview, teamComp, role, achievement, process,
                 techStack);
     }
 
@@ -148,8 +146,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeCompanyName(String companyName) {
-        return new Project(this.id, this.orderNo, companyName, this.period, this.name, this.overview, this.teamComp,
-                this.role,
+        return new Project(this.id, companyName, this.period, this.name, this.overview, this.teamComp, this.role,
                 this.achievement, this.process, this.techStack);
     }
 
@@ -160,8 +157,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changePeriod(Period period) {
-        return new Project(this.id, this.orderNo, this.companyName, period, this.name, this.overview, this.teamComp,
-                this.role,
+        return new Project(this.id, this.companyName, period, this.name, this.overview, this.teamComp, this.role,
                 this.achievement, this.process, this.techStack);
     }
 
@@ -172,8 +168,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeName(String name) {
-        return new Project(this.id, this.orderNo, this.companyName, this.period, name, this.overview, this.teamComp,
-                this.role,
+        return new Project(this.id, this.companyName, this.period, name, this.overview, this.teamComp, this.role,
                 this.achievement, this.process, this.techStack);
     }
 
@@ -184,8 +179,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeOverview(String overview) {
-        return new Project(this.id, this.orderNo, this.companyName, this.period, this.name, overview, this.teamComp,
-                this.role,
+        return new Project(this.id, this.companyName, this.period, this.name, overview, this.teamComp, this.role,
                 this.achievement, this.process, this.techStack);
     }
 
@@ -196,8 +190,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeTeamComp(String teamComp) {
-        return new Project(this.id, this.orderNo, this.companyName, this.period, this.name, this.overview, teamComp,
-                this.role,
+        return new Project(this.id, this.companyName, this.period, this.name, this.overview, teamComp, this.role,
                 this.achievement, this.process, this.techStack);
     }
 
@@ -208,8 +201,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeRole(String role) {
-        return new Project(this.id, this.orderNo, this.companyName, this.period, this.name, this.overview,
-                this.teamComp, role,
+        return new Project(this.id, this.companyName, this.period, this.name, this.overview, this.teamComp, role,
                 this.achievement, this.process, this.techStack);
     }
 
@@ -220,9 +212,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeAchievement(String achievement) {
-        return new Project(this.id, this.orderNo, this.companyName, this.period, this.name, this.overview,
-                this.teamComp,
-                this.role,
+        return new Project(this.id, this.companyName, this.period, this.name, this.overview, this.teamComp, this.role,
                 achievement, this.process, this.techStack);
     }
 
@@ -233,9 +223,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeProcess(Process process) {
-        return new Project(this.id, this.orderNo, this.companyName, this.period, this.name, this.overview,
-                this.teamComp,
-                this.role,
+        return new Project(this.id, this.companyName, this.period, this.name, this.overview, this.teamComp, this.role,
                 this.achievement, process, this.techStack);
     }
 
@@ -246,9 +234,7 @@ public class Project extends Entity {
      * @return 変更後のプロジェクトエンティティ
      */
     public Project changeTechStack(TechStack techStack) {
-        return new Project(this.id, this.orderNo, this.companyName, this.period, this.name, this.overview,
-                this.teamComp,
-                this.role,
+        return new Project(this.id, this.companyName, this.period, this.name, this.overview, this.teamComp, this.role,
                 this.achievement, this.process, techStack);
     }
 

--- a/backend/src/main/java/com/example/keirekipro/domain/model/resume/Resume.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/resume/Resume.java
@@ -115,13 +115,13 @@ public class Resume extends Entity {
     /**
      * 新規構築用のコンストラクタ
      */
-    private Resume(Notification notification, int orderNo, UUID userId, ResumeName name, LocalDate date,
+    private Resume(Notification notification, UUID userId, ResumeName name, LocalDate date,
             FullName fullName,
             boolean autoSaveEnabled,
             List<Career> careers, List<Project> projects,
             List<Certification> certifications, List<Portfolio> portfolios, List<SocialLink> socialLinks,
             List<SelfPromotion> selfPromotions) {
-        super(orderNo);
+        super();
         // サブエンティティや値オブジェクトのドメイン例外を一括でスローする
         if (notification.hasErrors()) {
             throw new DomainException(notification.getErrors());
@@ -144,12 +144,12 @@ public class Resume extends Entity {
     /**
      * 再構築用のコンストラクタ
      */
-    private Resume(UUID id, int orderNo, UUID userId, ResumeName name, LocalDate date, FullName fullName,
+    private Resume(UUID id, UUID userId, ResumeName name, LocalDate date, FullName fullName,
             boolean autoSaveEnabled,
             LocalDateTime createdAt, LocalDateTime updatedAt, List<Career> careers, List<Project> projects,
             List<Certification> certifications, List<Portfolio> portfolios, List<SocialLink> socialLinks,
             List<SelfPromotion> selfPromotions) {
-        super(id, orderNo);
+        super(id);
         this.userId = userId;
         this.name = name;
         this.date = date;
@@ -169,7 +169,6 @@ public class Resume extends Entity {
      * 新規構築用のファクトリーメソッド
      *
      * @param notification    通知オブジェクト
-     * @param orderNo         並び順
      * @param userId          ユーザーID
      * @param name            職務経歴書名
      * @param fullName        氏名
@@ -183,12 +182,12 @@ public class Resume extends Entity {
      * @param selfPromotions  自己PRリスト
      * @return 職務経歴書エンティティ
      */
-    public static Resume create(Notification notification, int orderNo, UUID userId, ResumeName name, LocalDate date,
+    public static Resume create(Notification notification, UUID userId, ResumeName name, LocalDate date,
             FullName fullName,
             boolean autoSaveEnabled, List<Career> careers,
             List<Project> projects, List<Certification> certifications, List<Portfolio> portfolios,
             List<SocialLink> socialLinks, List<SelfPromotion> selfPromotions) {
-        return new Resume(notification, orderNo, userId, name, date, fullName, autoSaveEnabled,
+        return new Resume(notification, userId, name, date, fullName, autoSaveEnabled,
                 careers,
                 projects,
                 certifications, portfolios, socialLinks, selfPromotions);
@@ -198,7 +197,6 @@ public class Resume extends Entity {
      * 再構築用のファクトリーメソッド
      *
      * @param id              識別子
-     * @param orderNo         並び順
      * @param userId          ユーザーID
      * @param name            職務経歴書名
      * @param fullName        氏名
@@ -214,13 +212,13 @@ public class Resume extends Entity {
      * @param selfPromotions  自己PRリスト
      * @return 職務経歴書エンティティ
      */
-    public static Resume reconstruct(UUID id, int orderNo, UUID userId, ResumeName name, LocalDate date,
+    public static Resume reconstruct(UUID id, UUID userId, ResumeName name, LocalDate date,
             FullName fullName,
             boolean autoSaveEnabled, LocalDateTime createdAt, LocalDateTime updatedAt,
             List<Career> careers, List<Project> projects, List<Certification> certifications,
             List<Portfolio> portfolios, List<SocialLink> socialLinks,
             List<SelfPromotion> selfPromotions) {
-        return new Resume(id, orderNo, userId, name, date, fullName, autoSaveEnabled, createdAt, updatedAt, careers,
+        return new Resume(id, userId, name, date, fullName, autoSaveEnabled, createdAt, updatedAt, careers,
                 projects,
                 certifications, portfolios, socialLinks, selfPromotions);
     }
@@ -232,9 +230,8 @@ public class Resume extends Entity {
      * @return 変更後の職務経歴書エンティティ
      */
     public Resume changeName(ResumeName name) {
-        return new Resume(this.id, this.orderNo, this.userId, name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects,
                 this.certifications, this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -246,9 +243,8 @@ public class Resume extends Entity {
      * @return 変更後の職務経歴書エンティティ
      */
     public Resume ChangeFullName(FullName fullName) {
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects,
                 this.certifications, this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -260,9 +256,8 @@ public class Resume extends Entity {
      * @return 変更後の職務経歴書エンティティ
      */
     public Resume changeDate(LocalDate date) {
-        return new Resume(this.id, this.orderNo, this.userId, this.name, date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects,
                 this.certifications, this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -274,9 +269,8 @@ public class Resume extends Entity {
      * @return 変更後の職務経歴書エンティティ
      */
     public Resume changeAutoSaveEnabled(boolean autoSaveEnabled) {
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects,
                 this.certifications, this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -294,9 +288,8 @@ public class Resume extends Entity {
         }
         List<Career> updatedCareers = new ArrayList<>(this.careers);
         updatedCareers.add(career);
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 updatedCareers, this.projects, this.certifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -315,9 +308,8 @@ public class Resume extends Entity {
         List<Career> updatedCareers = this.careers.stream()
                 .map(career -> career.getId().equals(updatedCareer.getId()) ? updatedCareer : career)
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 updatedCareers, this.projects, this.certifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -332,9 +324,8 @@ public class Resume extends Entity {
         List<Career> updatedCareers = this.careers.stream()
                 .filter(career -> !career.getId().equals(careerId))
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 updatedCareers, this.projects, this.certifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -407,9 +398,8 @@ public class Resume extends Entity {
         }
         List<Project> updatedProjects = new ArrayList<>(this.projects);
         updatedProjects.add(project);
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, updatedProjects, this.certifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -428,9 +418,8 @@ public class Resume extends Entity {
         List<Project> updatedProjects = this.projects.stream()
                 .map(project -> project.getId().equals(updatedProject.getId()) ? updatedProject : project)
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, updatedProjects, this.certifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -445,9 +434,8 @@ public class Resume extends Entity {
         List<Project> updatedProjects = this.projects.stream()
                 .filter(project -> !project.getId().equals(projectId))
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, updatedProjects, this.certifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -476,9 +464,8 @@ public class Resume extends Entity {
     public Resume addCertification(Certification certification) {
         List<Certification> updatedCertifications = new ArrayList<>(this.certifications);
         updatedCertifications.add(certification);
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, updatedCertifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -494,9 +481,8 @@ public class Resume extends Entity {
                 .map(certification -> certification.getId().equals(updatedCertification.getId()) ? updatedCertification
                         : certification)
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, updatedCertifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -511,9 +497,8 @@ public class Resume extends Entity {
         List<Certification> updatedCertifications = this.certifications.stream()
                 .filter(certification -> !certification.getId().equals(certificationId))
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, updatedCertifications,
                 this.portfolios, this.socialLinks, this.selfPromotions);
     }
@@ -527,9 +512,8 @@ public class Resume extends Entity {
     public Resume addPortfolio(Portfolio portfolio) {
         List<Portfolio> updatedPortfolios = new ArrayList<>(this.portfolios);
         updatedPortfolios.add(portfolio);
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 updatedPortfolios, this.socialLinks, this.selfPromotions);
     }
@@ -544,9 +528,8 @@ public class Resume extends Entity {
         List<Portfolio> updatedPortfolios = this.portfolios.stream()
                 .map(portfolio -> portfolio.getId().equals(updatedPortfolio.getId()) ? updatedPortfolio : portfolio)
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 updatedPortfolios, this.socialLinks, this.selfPromotions);
     }
@@ -561,9 +544,8 @@ public class Resume extends Entity {
         List<Portfolio> updatedPortfolios = this.portfolios.stream()
                 .filter(portfolio -> !portfolio.getId().equals(portfolioId))
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 updatedPortfolios, this.socialLinks, this.selfPromotions);
     }
@@ -577,9 +559,8 @@ public class Resume extends Entity {
     public Resume addSociealLink(SocialLink sociealLink) {
         List<SocialLink> updatedSocialLinks = new ArrayList<>(this.socialLinks);
         updatedSocialLinks.add(sociealLink);
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 this.portfolios, updatedSocialLinks, this.selfPromotions);
     }
@@ -595,9 +576,8 @@ public class Resume extends Entity {
                 .map(sociealLink -> sociealLink.getId().equals(updatedSociealLink.getId()) ? updatedSociealLink
                         : sociealLink)
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 this.portfolios, updatedSocialLinks, this.selfPromotions);
     }
@@ -612,9 +592,8 @@ public class Resume extends Entity {
         List<SocialLink> updatedSocialLinks = this.socialLinks.stream()
                 .filter(sociealLink -> !sociealLink.getId().equals(sociealLinkId))
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 this.portfolios, updatedSocialLinks, this.selfPromotions);
     }
@@ -628,9 +607,8 @@ public class Resume extends Entity {
     public Resume addSelfPromotion(SelfPromotion selfPromotion) {
         List<SelfPromotion> updatedSelfPromotions = new ArrayList<>(this.selfPromotions);
         updatedSelfPromotions.add(selfPromotion);
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 this.portfolios, this.socialLinks, updatedSelfPromotions);
     }
@@ -645,9 +623,8 @@ public class Resume extends Entity {
         List<SelfPromotion> updatedSelfPromotions = this.selfPromotions.stream()
                 .filter(selfPromotion -> !selfPromotion.getId().equals(selfPromotionId))
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 this.portfolios, this.socialLinks, updatedSelfPromotions);
     }
@@ -663,9 +640,8 @@ public class Resume extends Entity {
                 .map(selfPromotion -> selfPromotion.getId().equals(updatedSelfPromotion.getId()) ? updatedSelfPromotion
                         : selfPromotion)
                 .toList();
-        return new Resume(this.id, this.orderNo, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
-                this.createdAt, LocalDateTime
-                        .now(),
+        return new Resume(this.id, this.userId, this.name, this.date, this.fullName, this.autoSaveEnabled,
+                this.createdAt, LocalDateTime.now(),
                 this.careers, this.projects, this.certifications,
                 this.portfolios, this.socialLinks, updatedSelfPromotions);
     }

--- a/backend/src/main/java/com/example/keirekipro/domain/model/resume/SelfPromotion.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/resume/SelfPromotion.java
@@ -25,8 +25,8 @@ public class SelfPromotion extends Entity {
     /**
      * 新規構築用のコンストラクタ
      */
-    private SelfPromotion(int orderNo, String title, String content) {
-        super(orderNo);
+    private SelfPromotion(String title, String content) {
+        super();
         this.title = title;
         this.content = content;
     }
@@ -34,8 +34,8 @@ public class SelfPromotion extends Entity {
     /**
      * 再構築用のコンストラクタ
      */
-    private SelfPromotion(UUID id, int orderNo, String title, String content) {
-        super(id, orderNo);
+    private SelfPromotion(UUID id, String title, String content) {
+        super(id);
         this.title = title;
         this.content = content;
     }
@@ -43,26 +43,24 @@ public class SelfPromotion extends Entity {
     /**
      * 新規構築用のファクトリーメソッド
      *
-     * @param orderNo 並び順
      * @param title   タイトル
      * @param content コンテンツ
      * @return 自己PRエンティティ
      */
-    public static SelfPromotion create(int orderNo, String title, String content) {
-        return new SelfPromotion(orderNo, title, content);
+    public static SelfPromotion create(String title, String content) {
+        return new SelfPromotion(title, content);
     }
 
     /**
      * 再構築用のファクトリーメソッド
      *
      * @param id      識別子
-     * @param orderNo 並び順
      * @param title   タイトル
      * @param content コンテンツ
      * @return 自己PRエンティティ
      */
-    public static SelfPromotion reconstruct(UUID id, int orderNo, String title, String content) {
-        return new SelfPromotion(id, orderNo, title, content);
+    public static SelfPromotion reconstruct(UUID id, String title, String content) {
+        return new SelfPromotion(id, title, content);
     }
 
     /**
@@ -72,7 +70,7 @@ public class SelfPromotion extends Entity {
      * @return 変更後の自己PRエンティティ
      */
     public SelfPromotion changeTitle(String title) {
-        return new SelfPromotion(this.id, this.orderNo, title, this.content);
+        return new SelfPromotion(this.id, title, this.content);
     }
 
     /**
@@ -82,6 +80,6 @@ public class SelfPromotion extends Entity {
      * @return 変更後の自己PRエンティティ
      */
     public SelfPromotion changeContent(String content) {
-        return new SelfPromotion(this.id, this.orderNo, this.title, content);
+        return new SelfPromotion(this.id, this.title, content);
     }
 }

--- a/backend/src/main/java/com/example/keirekipro/domain/model/resume/SocialLink.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/resume/SocialLink.java
@@ -25,8 +25,8 @@ public class SocialLink extends Entity {
     /**
      * 新規構築用のコンストラクタ
      */
-    private SocialLink(int orderNo, String name, Link link) {
-        super(orderNo);
+    private SocialLink(String name, Link link) {
+        super();
         this.name = name;
         this.link = link;
     }
@@ -34,8 +34,8 @@ public class SocialLink extends Entity {
     /**
      * 再構築用のコンストラクタ
      */
-    private SocialLink(UUID id, int orderNo, String name, Link link) {
-        super(id, orderNo);
+    private SocialLink(UUID id, String name, Link link) {
+        super(id);
         this.name = name;
         this.link = link;
     }
@@ -43,26 +43,24 @@ public class SocialLink extends Entity {
     /**
      * 新規構築用のファクトリーメソッド
      *
-     * @param orderNo 並び順
-     * @param name    ソーシャル名
-     * @param link    リンク
+     * @param name ソーシャル名
+     * @param link リンク
      * @return ソーシャルリンクエンティティ
      */
-    public static SocialLink create(int orderNo, String name, Link link) {
-        return new SocialLink(orderNo, name, link);
+    public static SocialLink create(String name, Link link) {
+        return new SocialLink(name, link);
     }
 
     /**
      * 再構築用のファクトリーメソッド
      *
-     * @param id      識別子
-     * @param orderNo 並び順
-     * @param name    ソーシャル名
-     * @param link    リンク
+     * @param id   識別子
+     * @param name ソーシャル名
+     * @param link リンク
      * @return ソーシャルリンクエンティティ
      */
-    public static SocialLink reconstruct(UUID id, int orderNo, String name, Link link) {
-        return new SocialLink(id, orderNo, name, link);
+    public static SocialLink reconstruct(UUID id, String name, Link link) {
+        return new SocialLink(id, name, link);
     }
 
     /**
@@ -72,7 +70,7 @@ public class SocialLink extends Entity {
      * @return 変更後のソーシャルリンクエンティティ
      */
     public SocialLink changeName(String name) {
-        return new SocialLink(this.id, this.orderNo, name, this.link);
+        return new SocialLink(this.id, name, this.link);
     }
 
     /**
@@ -82,6 +80,6 @@ public class SocialLink extends Entity {
      * @return 変更後のソーシャルリンクエンティティ
      */
     public SocialLink changeLink(Link link) {
-        return new SocialLink(this.id, this.orderNo, this.name, link);
+        return new SocialLink(this.id, this.name, link);
     }
 }

--- a/backend/src/main/java/com/example/keirekipro/domain/model/user/AuthProvider.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/user/AuthProvider.java
@@ -50,7 +50,7 @@ public class AuthProvider extends Entity {
             LocalDateTime createdAt,
             LocalDateTime updatedAt) {
 
-        super(id, 1);
+        super(id);
         this.providerName = providerName == null ? null : providerName.toLowerCase();
         this.providerUserId = providerUserId;
         this.createdAt = createdAt;

--- a/backend/src/main/java/com/example/keirekipro/domain/model/user/User.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/model/user/User.java
@@ -77,14 +77,14 @@ public class User extends Entity {
      * 新規構築用のコンストラクタ
      */
     private User(Notification notification,
-            int orderNo,
             Email email,
             String passwordHash,
             boolean twoFactorAuthEnabled,
             Map<String, AuthProvider> authProviders,
             String profileImage,
             String username) {
-        super(orderNo);
+
+        super();
 
         // バリデーション実行
         validate(notification, email, passwordHash, authProviders);
@@ -109,7 +109,6 @@ public class User extends Entity {
      * 再構築用のコンストラクタ
      */
     private User(UUID id,
-            int orderNo,
             Email email,
             String passwordHash,
             boolean twoFactorAuthEnabled,
@@ -118,7 +117,7 @@ public class User extends Entity {
             String username,
             LocalDateTime createdAt,
             LocalDateTime updatedAt) {
-        super(id, orderNo);
+        super(id);
         this.email = email;
         this.passwordHash = passwordHash;
         this.twoFactorAuthEnabled = twoFactorAuthEnabled;
@@ -134,7 +133,6 @@ public class User extends Entity {
      * 新規構築用のファクトリーメソッド
      *
      * @param notification         通知オブジェクト
-     * @param orderNo              並び順
      * @param email                メールアドレス
      * @param passwordHash         パスワードハッシュ
      * @param twoFactorAuthEnabled 二段階認証設定
@@ -144,7 +142,6 @@ public class User extends Entity {
      * @return Userエンティティ
      */
     public static User create(Notification notification,
-            int orderNo,
             Email email,
             String passwordHash,
             boolean twoFactorAuthEnabled,
@@ -163,7 +160,6 @@ public class User extends Entity {
 
         return new User(
                 notification,
-                orderNo,
                 email,
                 passwordHash,
                 twoFactorAuthEnabled,
@@ -176,7 +172,6 @@ public class User extends Entity {
      * 再構築用のファクトリーメソッド
      *
      * @param id                   識別子
-     * @param orderNo              並び順
      * @param email                メールアドレス
      * @param passwordHash         パスワードハッシュ
      * @param twoFactorAuthEnabled 二段階認証設定
@@ -188,7 +183,6 @@ public class User extends Entity {
      * @return Userエンティティ
      */
     public static User reconstruct(UUID id,
-            int orderNo,
             Email email,
             String passwordHash,
             boolean twoFactorAuthEnabled,
@@ -206,7 +200,6 @@ public class User extends Entity {
 
         return new User(
                 id,
-                orderNo,
                 email,
                 passwordHash,
                 twoFactorAuthEnabled,
@@ -269,7 +262,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 this.email,
                 this.passwordHash,
                 this.twoFactorAuthEnabled,
@@ -300,7 +292,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 email,
                 this.passwordHash,
                 this.twoFactorAuthEnabled,
@@ -331,7 +322,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 this.email,
                 newPasswordHash,
                 this.twoFactorAuthEnabled,
@@ -352,7 +342,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 this.email,
                 newPasswordHash,
                 this.twoFactorAuthEnabled,
@@ -383,7 +372,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 this.email,
                 this.passwordHash,
                 twoFactorAuthEnabled,
@@ -422,7 +410,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 this.email,
                 this.passwordHash,
                 this.twoFactorAuthEnabled,
@@ -443,7 +430,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 this.email,
                 this.passwordHash,
                 this.twoFactorAuthEnabled,
@@ -482,7 +468,6 @@ public class User extends Entity {
 
         return new User(
                 this.id,
-                this.orderNo,
                 this.email,
                 this.passwordHash,
                 this.twoFactorAuthEnabled,

--- a/backend/src/main/java/com/example/keirekipro/domain/shared/Entity.java
+++ b/backend/src/main/java/com/example/keirekipro/domain/shared/Entity.java
@@ -20,36 +20,18 @@ public abstract class Entity implements Serializable {
     protected final UUID id;
 
     /**
-     * 並び順
-     */
-    protected int orderNo;
-
-    /**
      * 新規構築用のコンストラクター
-     *
-     * @param orderNo 並び順
      */
-    protected Entity(int orderNo) {
-        this(UUID.randomUUID(), orderNo);
+    protected Entity() {
+        this(UUID.randomUUID());
     }
 
     /**
      * 再構築用のコンストラクター
      *
-     * @param id      識別子
-     * @param orderNo 並び順
+     * @param id 識別子
      */
-    protected Entity(UUID id, int orderNo) {
+    protected Entity(UUID id) {
         this.id = id;
-        this.orderNo = orderNo;
-    }
-
-    /**
-     * 並び順を変更する
-     *
-     * @param orderNo 並び順
-     */
-    public void changeOrderNo(int orderNo) {
-        this.orderNo = orderNo;
     }
 }

--- a/backend/src/main/java/com/example/keirekipro/infrastructure/repository/user/MyBatisUserRepository.java
+++ b/backend/src/main/java/com/example/keirekipro/infrastructure/repository/user/MyBatisUserRepository.java
@@ -79,7 +79,6 @@ public class MyBatisUserRepository implements UserRepository {
 
         return User.reconstruct(
                 dto.getId(),
-                1,
                 dto.getEmail() != null ? Email.create(new Notification(), dto.getEmail()) : null,
                 dto.getPassword(),
                 dto.isTwoFactorAuthEnabled(),

--- a/backend/src/main/java/com/example/keirekipro/usecase/auth/OidcLoginUseCase.java
+++ b/backend/src/main/java/com/example/keirekipro/usecase/auth/OidcLoginUseCase.java
@@ -62,7 +62,6 @@ public class OidcLoginUseCase {
                     provider, AuthProvider.create(notification, provider, providerUserId));
             User newUser = User.create(
                     notification,
-                    1,
                     userInfo.getEmail() != null ? Email.create(notification, userInfo.getEmail()) : null,
                     null,
                     false,

--- a/backend/src/main/java/com/example/keirekipro/usecase/auth/UserRegistrationUseCase.java
+++ b/backend/src/main/java/com/example/keirekipro/usecase/auth/UserRegistrationUseCase.java
@@ -47,7 +47,6 @@ public class UserRegistrationUseCase {
         Notification notification = new Notification();
         User user = User.create(
                 notification,
-                1,
                 Email.create(
                         notification, request.getEmail()),
                 passwordEncoder.encode(request.getPassword()),

--- a/backend/src/main/resources/db/migration/V1__create_tables.sql
+++ b/backend/src/main/resources/db/migration/V1__create_tables.sql
@@ -46,8 +46,7 @@ CREATE TABLE resumes (
     date DATE NOT NULL,
     auto_save_enabled BOOLEAN NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
-    updated_at TIMESTAMP(6) NOT NULL,
-    order_no INTEGER NOT NULL
+    updated_at TIMESTAMP(6) NOT NULL
 );
 
 COMMENT ON TABLE resumes IS '職務経歴書';
@@ -58,7 +57,6 @@ COMMENT ON COLUMN resumes.date IS '作成日';
 COMMENT ON COLUMN resumes.auto_save_enabled IS '自動保存有効フラグ';
 COMMENT ON COLUMN resumes.created_at IS '作成日時';
 COMMENT ON COLUMN resumes.updated_at IS '更新日時';
-COMMENT ON COLUMN resumes.order_no IS '並び順';
 
 -- 職歴テーブル
 CREATE TABLE careers (
@@ -67,8 +65,7 @@ CREATE TABLE careers (
     company_name VARCHAR(255) NOT NULL,
     start_date DATE NOT NULL,
     end_date DATE NOT NULL,
-    is_active BOOLEAN NOT NULL,
-    order_no INTEGER NOT NULL
+    is_active BOOLEAN NOT NULL
 );
 
 COMMENT ON TABLE careers IS '職歴';
@@ -78,7 +75,6 @@ COMMENT ON COLUMN careers.company_name IS '会社名';
 COMMENT ON COLUMN careers.start_date IS '入社年月';
 COMMENT ON COLUMN careers.end_date IS '退職年月';
 COMMENT ON COLUMN careers.is_active IS '在籍中フラグ';
-COMMENT ON COLUMN careers.order_no IS '並び順';
 
 -- プロジェクトテーブル
 CREATE TABLE projects (
@@ -119,8 +115,7 @@ CREATE TABLE projects (
     communication_tools TEXT[],
     documentation_tools TEXT[],
     api_development_tools TEXT[],
-    design_tools TEXT[],
-    order_no INTEGER NOT NULL
+    design_tools TEXT[]
 );
 
 COMMENT ON TABLE projects IS 'プロジェクト';
@@ -162,15 +157,13 @@ COMMENT ON COLUMN projects.communication_tools IS 'コミュニケーション';
 COMMENT ON COLUMN projects.documentation_tools IS 'ドキュメント';
 COMMENT ON COLUMN projects.api_development_tools IS 'API開発';
 COMMENT ON COLUMN projects.design_tools IS 'デザイン';
-COMMENT ON COLUMN projects.order_no IS '並び順';
 
 -- 資格テーブル
 CREATE TABLE certifications (
     id UUID PRIMARY KEY,
     resume_id UUID NOT NULL REFERENCES resumes(id),
     name VARCHAR(255),
-    date DATE,
-    order_no INTEGER NOT NULL
+    date DATE
 );
 
 COMMENT ON TABLE certifications IS '資格';
@@ -178,7 +171,6 @@ COMMENT ON COLUMN certifications.id IS '識別子';
 COMMENT ON COLUMN certifications.resume_id IS '職務経歴書ID';
 COMMENT ON COLUMN certifications.name IS '資格名';
 COMMENT ON COLUMN certifications.date IS '取得日';
-COMMENT ON COLUMN certifications.order_no IS '並び順';
 
 -- ポートフォリオテーブル
 CREATE TABLE portfolios (
@@ -187,8 +179,7 @@ CREATE TABLE portfolios (
     name VARCHAR(255),
     overview VARCHAR(255),
     tech_stack TEXT,
-    link VARCHAR(255),
-    order_no INTEGER NOT NULL
+    link VARCHAR(255)
 );
 
 COMMENT ON TABLE portfolios IS 'ポートフォリオ';
@@ -198,15 +189,13 @@ COMMENT ON COLUMN portfolios.name IS 'ポートフォリオ名';
 COMMENT ON COLUMN portfolios.overview IS '概要';
 COMMENT ON COLUMN portfolios.tech_stack IS '技術スタック';
 COMMENT ON COLUMN portfolios.link IS 'リンク';
-COMMENT ON COLUMN portfolios.order_no IS '並び順';
 
 -- ソーシャルリンクテーブル
 CREATE TABLE social_links (
     id UUID PRIMARY KEY,
     resume_id UUID NOT NULL REFERENCES resumes(id),
     name VARCHAR(255),
-    link VARCHAR(255),
-    order_no INTEGER NOT NULL
+    link VARCHAR(255)
 );
 
 COMMENT ON TABLE social_links IS 'ソーシャルリンク';
@@ -214,15 +203,13 @@ COMMENT ON COLUMN social_links.id IS '識別子';
 COMMENT ON COLUMN social_links.resume_id IS '職務経歴書ID';
 COMMENT ON COLUMN social_links.name IS 'ソーシャルリンク名';
 COMMENT ON COLUMN social_links.link IS 'リンク';
-COMMENT ON COLUMN social_links.order_no IS '並び順';
 
 -- 自己PRテーブル
 CREATE TABLE self_promotions (
     id UUID PRIMARY KEY,
     resume_id UUID NOT NULL REFERENCES resumes(id),
     title VARCHAR(255),
-    content TEXT,
-    order_no INTEGER NOT NULL
+    content TEXT
 );
 
 COMMENT ON TABLE self_promotions IS '自己PR';
@@ -230,7 +217,6 @@ COMMENT ON COLUMN self_promotions.id IS '識別子';
 COMMENT ON COLUMN self_promotions.resume_id IS '職務経歴書ID';
 COMMENT ON COLUMN self_promotions.title IS 'タイトル';
 COMMENT ON COLUMN self_promotions.content IS 'コンテンツ';
-COMMENT ON COLUMN self_promotions.order_no IS '並び順';
 
 -- 技術スタックカテゴリマスタテーブル
 CREATE TABLE tech_stack_category_mst (

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/CareerTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/CareerTest.java
@@ -25,11 +25,10 @@ class CareerTest {
     @DisplayName("新規構築用コンストラクタでインスタンス化する")
     void test1() {
         Period period = Period.create(notification, YearMonth.of(2025, 01), YearMonth.of(2025, 02), false);
-        Career career = Career.create(0, "株式会社ABC", period);
+        Career career = Career.create("株式会社ABC", period);
 
         assertThat(career).isNotNull();
         assertThat(career.getId()).isNotNull();
-        assertThat(career.getOrderNo()).isEqualTo(0);
         assertThat(career.getCompanyName()).isEqualTo("株式会社ABC");
         assertThat(career.getPeriod()).isEqualTo(period);
     }
@@ -39,11 +38,10 @@ class CareerTest {
     void test2() {
         Period period = Period.create(notification, YearMonth.of(2025, 01), YearMonth.of(2025, 02), false);
         UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-        Career career = Career.reconstruct(id, 0, "株式会社ABC", period);
+        Career career = Career.reconstruct(id, "株式会社ABC", period);
 
         assertThat(career).isNotNull();
         assertThat(career.getId()).isEqualTo(id);
-        assertThat(career.getOrderNo()).isEqualTo(0);
         assertThat(career.getCompanyName()).isEqualTo("株式会社ABC");
         assertThat(career.getPeriod()).isEqualTo(period);
     }
@@ -52,7 +50,7 @@ class CareerTest {
     @DisplayName("会社名を変更する")
     void test3() {
         Period period = Period.create(notification, YearMonth.of(2025, 01), YearMonth.of(2025, 02), false);
-        Career beforeCareer = Career.create(0, "株式会社ABC", period);
+        Career beforeCareer = Career.create("株式会社ABC", period);
         Career afterCareer = beforeCareer.changeCompanyName("株式会社ZZZ");
 
         assertThat(afterCareer.getCompanyName()).isEqualTo("株式会社ZZZ");
@@ -62,7 +60,7 @@ class CareerTest {
     @DisplayName("期間を変更する")
     void test4() {
         Period beforePeriod = Period.create(notification, YearMonth.of(2025, 01), YearMonth.of(2025, 02), false);
-        Career beforeCareer = Career.create(0, "株式会社ABC", beforePeriod);
+        Career beforeCareer = Career.create("株式会社ABC", beforePeriod);
         Period afterPeriod = Period.create(notification, YearMonth.of(2030, 01), null, true);
         Career afterCareer = beforeCareer.changePeriod(afterPeriod);
 
@@ -73,7 +71,7 @@ class CareerTest {
     @DisplayName("会社名、期間を変更する")
     void test5() {
         Period beforePeriod = Period.create(notification, YearMonth.of(2025, 01), YearMonth.of(2025, 02), false);
-        Career beforeCareer = Career.create(0, "株式会社ABC", beforePeriod);
+        Career beforeCareer = Career.create("株式会社ABC", beforePeriod);
         Period afterPeriod = Period.create(notification, YearMonth.of(2030, 01), null, true);
         Career afterCareer = beforeCareer.changePeriod(afterPeriod).changeCompanyName("株式会社ZZZ");
 

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/CertificationTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/CertificationTest.java
@@ -15,11 +15,10 @@ class CertificationTest {
     @Test
     @DisplayName("新規構築用コンストラクタでインスタンス化する")
     void test1() {
-        Certification certification = Certification.create(0, "基本情報技術者", YearMonth.of(2025, 01));
+        Certification certification = Certification.create("基本情報技術者", YearMonth.of(2025, 01));
 
         assertThat(certification).isNotNull();
         assertThat(certification.getId()).isNotNull();
-        assertThat(certification.getOrderNo()).isEqualTo(0);
         assertThat(certification.getName()).isEqualTo("基本情報技術者");
         assertThat(certification.getDate()).isEqualTo(YearMonth.of(2025, 01));
     }
@@ -28,11 +27,10 @@ class CertificationTest {
     @DisplayName("再構築用コンストラクタでインスタンス化する")
     void test2() {
         UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-        Certification certification = Certification.reconstruct(id, 0, "基本情報技術者", YearMonth.of(2025, 01));
+        Certification certification = Certification.reconstruct(id, "基本情報技術者", YearMonth.of(2025, 01));
 
         assertThat(certification).isNotNull();
         assertThat(certification.getId()).isEqualTo(id);
-        assertThat(certification.getOrderNo()).isEqualTo(0);
         assertThat(certification.getName()).isEqualTo("基本情報技術者");
         assertThat(certification.getDate()).isEqualTo(YearMonth.of(2025, 01));
     }
@@ -40,7 +38,7 @@ class CertificationTest {
     @Test
     @DisplayName("資格名を変更する")
     void test3() {
-        Certification beforeCertification = Certification.create(0, "基本情報技術者", YearMonth.of(2025, 01));
+        Certification beforeCertification = Certification.create("基本情報技術者", YearMonth.of(2025, 01));
         Certification afteCertification = beforeCertification.changeName("応用情報技術者");
 
         assertThat(afteCertification.getName()).isEqualTo("応用情報技術者");
@@ -49,7 +47,7 @@ class CertificationTest {
     @Test
     @DisplayName("取得年月を変更する")
     void test4() {
-        Certification beforeCertification = Certification.create(0, "基本情報技術者", YearMonth.of(2025, 01));
+        Certification beforeCertification = Certification.create("基本情報技術者", YearMonth.of(2025, 01));
         Certification afteCertification = beforeCertification.changeDate(YearMonth.of(2030, 01));
 
         assertThat(afteCertification.getDate()).isEqualTo(YearMonth.of(2030, 01));
@@ -58,7 +56,7 @@ class CertificationTest {
     @Test
     @DisplayName("資格名、取得年月を変更する")
     void test5() {
-        Certification beforeCertification = Certification.create(0, "基本情報技術者", YearMonth.of(2025, 01));
+        Certification beforeCertification = Certification.create("基本情報技術者", YearMonth.of(2025, 01));
         Certification afteCertification = beforeCertification.changeDate(YearMonth.of(2030, 01)).changeName("応用情報技術者");
 
         assertThat(afteCertification.getDate()).isEqualTo(YearMonth.of(2030, 01));

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/PortfolioTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/PortfolioTest.java
@@ -24,11 +24,10 @@ class PortfolioTest {
     @DisplayName("新規構築用コンストラクタでインスタンス化する")
     void test1() {
         Link link = Link.create(notification, "https://example.com");
-        Portfolio portfolio = Portfolio.create(0, "ポートフォリオ名", "概要説明", "Java, Spring, React", link);
+        Portfolio portfolio = Portfolio.create("ポートフォリオ名", "概要説明", "Java, Spring, React", link);
 
         assertThat(portfolio).isNotNull();
         assertThat(portfolio.getId()).isNotNull();
-        assertThat(portfolio.getOrderNo()).isEqualTo(0);
         assertThat(portfolio.getName()).isEqualTo("ポートフォリオ名");
         assertThat(portfolio.getOverview()).isEqualTo("概要説明");
         assertThat(portfolio.getTechStack()).isEqualTo("Java, Spring, React");
@@ -40,11 +39,10 @@ class PortfolioTest {
     void test2() {
         Link link = Link.create(notification, "https://example.com");
         UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-        Portfolio portfolio = Portfolio.reconstruct(id, 0, "ポートフォリオ名", "概要説明", "Java, Spring, React", link);
+        Portfolio portfolio = Portfolio.reconstruct(id, "ポートフォリオ名", "概要説明", "Java, Spring, React", link);
 
         assertThat(portfolio).isNotNull();
         assertThat(portfolio.getId()).isEqualTo(id);
-        assertThat(portfolio.getOrderNo()).isEqualTo(0);
         assertThat(portfolio.getName()).isEqualTo("ポートフォリオ名");
         assertThat(portfolio.getOverview()).isEqualTo("概要説明");
         assertThat(portfolio.getTechStack()).isEqualTo("Java, Spring, React");
@@ -55,7 +53,7 @@ class PortfolioTest {
     @DisplayName("ポートフォリオ名を変更する")
     void test3() {
         Link link = Link.create(notification, "https://example.com");
-        Portfolio beforePortfolio = Portfolio.create(0, "ポートフォリオ名", "概要説明", "Java, Spring, React", link);
+        Portfolio beforePortfolio = Portfolio.create("ポートフォリオ名", "概要説明", "Java, Spring, React", link);
         Portfolio afterPortfolio = beforePortfolio.changeName("新しいポートフォリオ名");
 
         assertThat(afterPortfolio.getName()).isEqualTo("新しいポートフォリオ名");
@@ -65,7 +63,7 @@ class PortfolioTest {
     @DisplayName("ポートフォリオ概要を変更する")
     void test4() {
         Link link = Link.create(notification, "https://example.com");
-        Portfolio beforePortfolio = Portfolio.create(0, "ポートフォリオ名", "概要説明", "Java, Spring, React", link);
+        Portfolio beforePortfolio = Portfolio.create("ポートフォリオ名", "概要説明", "Java, Spring, React", link);
         Portfolio afterPortfolio = beforePortfolio.changeOverview("新しい概要説明");
 
         assertThat(afterPortfolio.getOverview()).isEqualTo("新しい概要説明");
@@ -75,7 +73,7 @@ class PortfolioTest {
     @DisplayName("技術スタックを変更する")
     void test5() {
         Link link = Link.create(notification, "https://example.com");
-        Portfolio beforePortfolio = Portfolio.create(0, "ポートフォリオ名", "概要説明", "Java, Spring, React", link);
+        Portfolio beforePortfolio = Portfolio.create("ポートフォリオ名", "概要説明", "Java, Spring, React", link);
         Portfolio afterPortfolio = beforePortfolio.changeTechStack("TypeScript, Node.js");
 
         assertThat(afterPortfolio.getTechStack()).isEqualTo("TypeScript, Node.js");
@@ -85,7 +83,7 @@ class PortfolioTest {
     @DisplayName("リンクを変更する")
     void test6() {
         Link beforeLink = Link.create(notification, "https://example.com");
-        Portfolio beforePortfolio = Portfolio.create(0, "ポートフォリオ名", "概要説明", "Java, Spring, React", beforeLink);
+        Portfolio beforePortfolio = Portfolio.create("ポートフォリオ名", "概要説明", "Java, Spring, React", beforeLink);
         Link afterLink = Link.create(notification, "https://github.com");
         Portfolio afterPortfolio = beforePortfolio.changeLink(afterLink);
 
@@ -96,7 +94,7 @@ class PortfolioTest {
     @DisplayName("ポートフォリオ名、概要、技術スタック、リンクを変更する")
     void test7() {
         Link beforeLink = Link.create(notification, "https://example.com");
-        Portfolio beforePortfolio = Portfolio.create(0, "ポートフォリオ名", "概要説明", "Java, Spring, React", beforeLink);
+        Portfolio beforePortfolio = Portfolio.create("ポートフォリオ名", "概要説明", "Java, Spring, React", beforeLink);
         Link afterLink = Link.create(notification, "https://github.com");
         Portfolio afterPortfolio = beforePortfolio.changeName("新しいポートフォリオ名")
                 .changeOverview("新しい概要説明")

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/ProjectTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/ProjectTest.java
@@ -29,12 +29,11 @@ class ProjectTest {
         Period period = Period.create(notification, YearMonth.of(2023, 1), YearMonth.of(2023, 12), false);
         TechStack techStack = createSampleTechStack();
         Project.Process process = createSampleProcess();
-        Project project = Project.create(0, "株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容", process,
+        Project project = Project.create("株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容", process,
                 techStack);
 
         assertThat(project).isNotNull();
         assertThat(project.getId()).isNotNull();
-        assertThat(project.getOrderNo()).isEqualTo(0);
         assertThat(project.getCompanyName()).isEqualTo("株式会社ABC");
         assertThat(project.getPeriod()).isEqualTo(period);
         assertThat(project.getName()).isEqualTo("プロジェクト名");
@@ -53,13 +52,12 @@ class ProjectTest {
         TechStack techStack = createSampleTechStack();
         Project.Process process = createSampleProcess();
         UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-        Project project = Project.reconstruct(id, 0, "株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容",
+        Project project = Project.reconstruct(id, "株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容",
                 process,
                 techStack);
 
         assertThat(project).isNotNull();
         assertThat(project.getId()).isEqualTo(id);
-        assertThat(project.getOrderNo()).isEqualTo(0);
         assertThat(project.getCompanyName()).isEqualTo("株式会社ABC");
         assertThat(project.getPeriod()).isEqualTo(period);
         assertThat(project.getName()).isEqualTo("プロジェクト名");
@@ -214,7 +212,7 @@ class ProjectTest {
         Period period = Period.create(notification, YearMonth.of(2023, 1), YearMonth.of(2023, 12), false);
         TechStack techStack = createSampleTechStack();
         Project.Process process = createSampleProcess();
-        return Project.create(0, "株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容", process, techStack);
+        return Project.create("株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容", process, techStack);
     }
 
     private TechStack createSampleTechStack() {

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/ResumeTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/ResumeTest.java
@@ -48,7 +48,6 @@ class ResumeTest {
 
         assertThat(resume).isNotNull();
         assertThat(resume.getId()).isNotNull();
-        assertThat(resume.getOrderNo()).isEqualTo(0);
         assertThat(resume.getUserId()).isEqualTo(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
         assertThat(resume.getName()).isEqualTo(ResumeName.create(notification, "職務経歴書A"));
         assertThat(resume.getDate()).isEqualTo(LocalDate.now());
@@ -69,7 +68,6 @@ class ResumeTest {
         assertThatThrownBy(() -> {
             Resume.create(
                     invalidNotification,
-                    0,
                     userId,
                     null, // 名前がnull
                     LocalDate.now(),
@@ -91,7 +89,6 @@ class ResumeTest {
         UUID userId = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
         Resume resume = Resume.reconstruct(
                 id,
-                0,
                 userId,
                 ResumeName.create(notification, "職務経歴書A"),
                 LocalDate.of(2023, 1, 1),
@@ -108,7 +105,6 @@ class ResumeTest {
 
         assertThat(resume).isNotNull();
         assertThat(resume.getId()).isEqualTo(id);
-        assertThat(resume.getOrderNo()).isEqualTo(0);
         assertThat(resume.getUserId()).isEqualTo(userId);
         assertThat(resume.getName()).isEqualTo(ResumeName.create(notification, "職務経歴書A"));
         assertThat(resume.getDate()).isEqualTo(LocalDate.of(2023, 1, 1));
@@ -158,7 +154,7 @@ class ResumeTest {
     @DisplayName("正常な値で職歴を追加する")
     void test7() {
         Resume beforeResume = createSampleResume();
-        Career newCareer = Career.create(1, "株式会社DEF",
+        Career newCareer = Career.create("株式会社DEF",
                 Period.create(notification, YearMonth.of(2024, 1), null, true));
         Resume afterResume = beforeResume.addCareer(notification, newCareer);
 
@@ -175,13 +171,12 @@ class ResumeTest {
         UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         Resume resume = Resume.create(
                 notification,
-                0,
                 userId,
                 ResumeName.create(notification, "職務経歴書A"),
                 LocalDate.now(),
                 FullName.create(notification, "山田", "太郎"),
                 true,
-                List.of(Career.create(0, "株式会社ABC",
+                List.of(Career.create("株式会社ABC",
                         Period.create(notification, YearMonth.of(2024, 1), null, true))),
                 List.of(),
                 List.of(),
@@ -191,7 +186,7 @@ class ResumeTest {
 
         // DomainExceptionがスローされる
         assertThatThrownBy(() -> {
-            resume.addCareer(notification, Career.create(1, "株式会社DEF",
+            resume.addCareer(notification, Career.create("株式会社DEF",
                     Period.create(notification, YearMonth.of(2024, 2), YearMonth.of(2024, 3), false)));
         }).isInstanceOf(DomainException.class);
 
@@ -211,7 +206,7 @@ class ResumeTest {
 
         // DomainExceptionがスローされる
         assertThatThrownBy(() -> {
-            resume.addCareer(notification, Career.create(1, "株式会社DEF",
+            resume.addCareer(notification, Career.create("株式会社DEF",
                     Period.create(notification, YearMonth.of(2020, 1), YearMonth.of(2023, 12), false)));
         }).isInstanceOf(DomainException.class);
 
@@ -230,13 +225,12 @@ class ResumeTest {
         UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         Resume resume = Resume.create(
                 notification,
-                0,
                 userId,
                 ResumeName.create(notification, "職務経歴書A"),
                 LocalDate.now(),
                 FullName.create(notification, "山田", "太郎"),
                 true,
-                List.of(Career.create(0, "株式会社ABC",
+                List.of(Career.create("株式会社ABC",
                         Period.create(notification, YearMonth.of(2024, 1), null, true))),
                 List.of(),
                 List.of(),
@@ -246,7 +240,7 @@ class ResumeTest {
 
         // DomainExceptionがスローされる
         assertThatThrownBy(() -> {
-            resume.addCareer(notification, Career.create(1, "株式会社DEF",
+            resume.addCareer(notification, Career.create("株式会社DEF",
                     Period.create(notification, YearMonth.of(2024, 2), null, true)));
         }).isInstanceOf(DomainException.class);
 
@@ -266,7 +260,7 @@ class ResumeTest {
 
         // DomainExceptionがスローされる
         assertThatThrownBy(() -> {
-            resume.addCareer(notification, Career.create(1, "株式会社DEF",
+            resume.addCareer(notification, Career.create("株式会社DEF",
                     Period.create(notification, YearMonth.of(2023, 10), YearMonth.of(2024, 11), false)));
         }).isInstanceOf(DomainException.class);
 
@@ -286,7 +280,7 @@ class ResumeTest {
 
         // DomainExceptionがスローされる
         assertThatThrownBy(() -> {
-            resume.addCareer(notification, Career.create(1, "株式会社DEF",
+            resume.addCareer(notification, Career.create("株式会社DEF",
                     Period.create(notification, YearMonth.of(2023, 11), YearMonth.of(2024, 6), false)));
         }).isInstanceOf(DomainException.class);
 
@@ -300,7 +294,7 @@ class ResumeTest {
     @DisplayName("正常な値で職歴を更新する")
     void test13() {
         Resume beforeResume = createSampleResume();
-        Career newCareer = Career.reconstruct(beforeResume.getCareers().get(0).getId(), 0, "株式会社DEF",
+        Career newCareer = Career.reconstruct(beforeResume.getCareers().get(0).getId(), "株式会社DEF",
                 Period.create(notification, YearMonth.of(2024, 1), null, true));
         Resume afterResume = beforeResume.updateCareer(notification, newCareer);
 
@@ -311,7 +305,6 @@ class ResumeTest {
         // 更新した職歴の値が正しい
         assertThat(afterResume.getCareers().get(0).getCompanyName()).isEqualTo(newCareer.getCompanyName());
         assertThat(afterResume.getCareers().get(0).getPeriod()).isEqualTo(newCareer.getPeriod());
-        assertThat(afterResume.getCareers().get(0).getOrderNo()).isEqualTo(newCareer.getOrderNo());
         assertThat(afterResume.getCareers().get(0).getId()).isEqualTo(beforeResume.getCareers().get(0).getId());
     }
 
@@ -319,7 +312,7 @@ class ResumeTest {
     @DisplayName("職歴を削除する")
     void test14() {
         Resume beforeResume = createSampleResume();
-        Career newCareer = Career.create(1, "株式会社DEF",
+        Career newCareer = Career.create("株式会社DEF",
                 Period.create(notification, YearMonth.of(2024, 1), null, true));
         Resume afterResume = beforeResume.addCareer(notification, newCareer);
         // 削除1回目(2件 → 1件)
@@ -378,7 +371,6 @@ class ResumeTest {
         Project originalProject = beforeResume.getProjects().get(0);
         Project updatedProject = Project.reconstruct(
                 originalProject.getId(),
-                originalProject.getOrderNo(),
                 originalProject.getCompanyName(), // 会社名は変更しない
                 originalProject.getPeriod(),
                 "新しいプロジェクト名",
@@ -448,7 +440,6 @@ class ResumeTest {
 
         // 削除対象のプロジェクトを追加
         Project newProject = Project.create(
-                1,
                 "株式会社DEF",
                 Period.create(notification, YearMonth.of(2022, 1), YearMonth.of(2023, 1), false),
                 "プロジェクト概要",
@@ -501,7 +492,7 @@ class ResumeTest {
     @DisplayName("資格を追加する")
     void test19() {
         Resume beforeResume = createSampleResume();
-        Certification newCertification = Certification.create(1, "応用情報技術者", YearMonth.of(2025, 02));
+        Certification newCertification = Certification.create("応用情報技術者", YearMonth.of(2025, 02));
         Resume afterResume = beforeResume.addCertification(newCertification);
 
         // 新しい資格がリストに含まれている
@@ -514,7 +505,7 @@ class ResumeTest {
     @DisplayName("資格を更新する")
     void test20() {
         Resume beforeResume = createSampleResume();
-        Certification newCertification = Certification.reconstruct(beforeResume.getCertifications().get(0).getId(), 0,
+        Certification newCertification = Certification.reconstruct(beforeResume.getCertifications().get(0).getId(),
                 "応用情報技術者", YearMonth.of(2025, 02));
         Resume afterResume = beforeResume.updateCertification(newCertification);
 
@@ -528,8 +519,6 @@ class ResumeTest {
                         .isEqualTo(newCertification.getName()),
                 () -> assertThat(afterResume.getCertifications().get(0).getDate())
                         .isEqualTo(newCertification.getDate()),
-                () -> assertThat(afterResume.getCertifications().get(0).getOrderNo())
-                        .isEqualTo(newCertification.getOrderNo()),
                 () -> assertThat(afterResume.getCertifications().get(0).getId())
                         .isEqualTo(beforeResume.getCertifications().get(0).getId()));
     }
@@ -538,7 +527,7 @@ class ResumeTest {
     @DisplayName("資格を削除する")
     void test21() {
         Resume beforeResume = createSampleResume();
-        Certification newCertification = Certification.create(1, "応用情報技術者", YearMonth.of(2025, 02));
+        Certification newCertification = Certification.create("応用情報技術者", YearMonth.of(2025, 02));
         Resume afterResume = beforeResume.addCertification(newCertification);
 
         // 削除1回目(2件 → 1件)
@@ -559,7 +548,6 @@ class ResumeTest {
     void test22() {
         Resume beforeResume = createSampleResume();
         Portfolio newPortfolio = Portfolio.create(
-                1,
                 "新しいポートフォリオ",
                 "新しいポートフォリオの概要",
                 "新しい技術スタック",
@@ -579,7 +567,6 @@ class ResumeTest {
         Resume beforeResume = createSampleResume();
         Portfolio updatedPortfolio = Portfolio.reconstruct(
                 beforeResume.getPortfolios().get(0).getId(),
-                0,
                 "更新されたポートフォリオ",
                 "更新されたポートフォリオの概要",
                 "更新された技術スタック",
@@ -608,7 +595,6 @@ class ResumeTest {
     void test24() {
         Resume beforeResume = createSampleResume();
         Portfolio newPortfolio = Portfolio.create(
-                1,
                 "削除対象のポートフォリオ",
                 "削除対象の概要",
                 "削除対象の技術スタック",
@@ -634,7 +620,6 @@ class ResumeTest {
     void test25() {
         Resume beforeResume = createSampleResume();
         SocialLink newSocialLink = SocialLink.create(
-                1,
                 "Twitter",
                 Link.create(notification, "https://twitter.com/user"));
 
@@ -652,7 +637,6 @@ class ResumeTest {
         Resume beforeResume = createSampleResume();
         SocialLink updatedSocialLink = SocialLink.reconstruct(
                 beforeResume.getSocialLinks().get(0).getId(),
-                0,
                 "LinkedIn",
                 Link.create(notification, "https://linkedin.com/in/user"));
 
@@ -673,7 +657,6 @@ class ResumeTest {
     void test27() {
         Resume beforeResume = createSampleResume();
         SocialLink newSocialLink = SocialLink.create(
-                1,
                 "Facebook",
                 Link.create(notification, "https://facebook.com/user"));
 
@@ -697,7 +680,6 @@ class ResumeTest {
     void test28() {
         Resume beforeResume = createSampleResume();
         SelfPromotion newSelfPromotion = SelfPromotion.create(
-                1,
                 "新しいタイトル",
                 "新しい自己PRの内容");
 
@@ -715,7 +697,6 @@ class ResumeTest {
         Resume beforeResume = createSampleResume();
         SelfPromotion updatedSelfPromotion = SelfPromotion.reconstruct(
                 beforeResume.getSelfPromotions().get(0).getId(),
-                0,
                 "更新されたタイトル",
                 "更新された自己PRの内容");
 
@@ -740,7 +721,6 @@ class ResumeTest {
     void test30() {
         Resume beforeResume = createSampleResume();
         SelfPromotion newSelfPromotion = SelfPromotion.create(
-                1,
                 "削除対象のタイトル",
                 "削除対象の自己PRの内容");
 
@@ -776,7 +756,6 @@ class ResumeTest {
         UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         return Resume.create(
                 notification,
-                0,
                 userId,
                 ResumeName.create(notification, "職務経歴書A"),
                 LocalDate.now(),
@@ -795,7 +774,7 @@ class ResumeTest {
      */
     private Career createSampleCareer() {
         Period period = Period.create(notification, YearMonth.of(2020, 1), YearMonth.of(2023, 12), false);
-        return Career.create(0, "株式会社ABC", period);
+        return Career.create("株式会社ABC", period);
     }
 
     /**
@@ -828,34 +807,34 @@ class ResumeTest {
                         List.of("Postman"),
                         List.of("Figma")));
         Project.Process process = Project.Process.create(true, true, true, true, true, true, true);
-        return Project.create(0, "株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容", process, techStack);
+        return Project.create("株式会社ABC", period, "プロジェクト名", "プロジェクト概要", "5人", "リーダー", "成果内容", process, techStack);
     }
 
     /**
      * 資格のサンプルエンティティを作成する補助メソッド
      */
     private Certification createSampleCertification() {
-        return Certification.create(0, "基本情報技術者", YearMonth.of(2025, 01));
+        return Certification.create("基本情報技術者", YearMonth.of(2025, 01));
     }
 
     /**
      * ポートフォリオのサンプルエンティティを作成する補助メソッド
      */
     private Portfolio createSamplePortfolio() {
-        return Portfolio.create(0, "ポートフォリオ名", "概要", "技術スタック", Link.create(notification, "https://portfolio.com"));
+        return Portfolio.create("ポートフォリオ名", "概要", "技術スタック", Link.create(notification, "https://portfolio.com"));
     }
 
     /**
      * ソーシャルリンクのサンプルエンティティを作成する補助メソッド
      */
     private SocialLink createSampleSociealLink() {
-        return SocialLink.create(0, "GitHub", Link.create(notification, "https://github.com/user"));
+        return SocialLink.create("GitHub", Link.create(notification, "https://github.com/user"));
     }
 
     /**
      * 自己PRのサンプルエンティティを作成する補助メソッド
      */
     private SelfPromotion createSampleSelfPromotion() {
-        return SelfPromotion.create(0, "自己PRタイトル", "自己PR内容");
+        return SelfPromotion.create("自己PRタイトル", "自己PR内容");
     }
 }

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/SelfPromotionTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/SelfPromotionTest.java
@@ -14,11 +14,10 @@ class SelfPromotionTest {
     @Test
     @DisplayName("新規構築用コンストラクタでインスタンス化する")
     void test1() {
-        SelfPromotion selfPromotion = SelfPromotion.create(0, "タイトル", "自己PRコンテンツ");
+        SelfPromotion selfPromotion = SelfPromotion.create("タイトル", "自己PRコンテンツ");
 
         assertThat(selfPromotion).isNotNull();
         assertThat(selfPromotion.getId()).isNotNull();
-        assertThat(selfPromotion.getOrderNo()).isEqualTo(0);
         assertThat(selfPromotion.getTitle()).isEqualTo("タイトル");
         assertThat(selfPromotion.getContent()).isEqualTo("自己PRコンテンツ");
     }
@@ -27,11 +26,10 @@ class SelfPromotionTest {
     @DisplayName("再構築用コンストラクタでインスタンス化する")
     void test2() {
         UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-        SelfPromotion selfPromotion = SelfPromotion.reconstruct(id, 0, "タイトル", "自己PRコンテンツ");
+        SelfPromotion selfPromotion = SelfPromotion.reconstruct(id, "タイトル", "自己PRコンテンツ");
 
         assertThat(selfPromotion).isNotNull();
         assertThat(selfPromotion.getId()).isEqualTo(id);
-        assertThat(selfPromotion.getOrderNo()).isEqualTo(0);
         assertThat(selfPromotion.getTitle()).isEqualTo("タイトル");
         assertThat(selfPromotion.getContent()).isEqualTo("自己PRコンテンツ");
     }
@@ -39,7 +37,7 @@ class SelfPromotionTest {
     @Test
     @DisplayName("タイトルを変更する")
     void test3() {
-        SelfPromotion beforeSelfPromotion = SelfPromotion.create(0, "タイトル", "自己PRコンテンツ");
+        SelfPromotion beforeSelfPromotion = SelfPromotion.create("タイトル", "自己PRコンテンツ");
         SelfPromotion afterSelfPromotion = beforeSelfPromotion.changeTitle("新しいタイトル");
 
         assertThat(afterSelfPromotion.getTitle()).isEqualTo("新しいタイトル");
@@ -48,7 +46,7 @@ class SelfPromotionTest {
     @Test
     @DisplayName("コンテンツを変更する")
     void test4() {
-        SelfPromotion beforeSelfPromotion = SelfPromotion.create(0, "タイトル", "自己PRコンテンツ");
+        SelfPromotion beforeSelfPromotion = SelfPromotion.create("タイトル", "自己PRコンテンツ");
         SelfPromotion afterSelfPromotion = beforeSelfPromotion.changeContent("新しい自己PRコンテンツ");
 
         assertThat(afterSelfPromotion.getContent()).isEqualTo("新しい自己PRコンテンツ");
@@ -57,7 +55,7 @@ class SelfPromotionTest {
     @Test
     @DisplayName("タイトル、コンテンツを変更する")
     void test5() {
-        SelfPromotion beforeSelfPromotion = SelfPromotion.create(0, "タイトル", "自己PRコンテンツ");
+        SelfPromotion beforeSelfPromotion = SelfPromotion.create("タイトル", "自己PRコンテンツ");
         SelfPromotion afterSelfPromotion = beforeSelfPromotion.changeContent("新しい自己PRコンテンツ")
                 .changeTitle("新しいタイトル");
 

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/SociealLinkTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/resume/SociealLinkTest.java
@@ -24,11 +24,10 @@ class SociealLinkTest {
     @DisplayName("新規構築用コンストラクタでインスタンス化する")
     void test1() {
         Link link = Link.create(notification, "https://example.com");
-        SocialLink sociealLink = SocialLink.create(0, "GitHub", link);
+        SocialLink sociealLink = SocialLink.create("GitHub", link);
 
         assertThat(sociealLink).isNotNull();
         assertThat(sociealLink.getId()).isNotNull();
-        assertThat(sociealLink.getOrderNo()).isEqualTo(0);
         assertThat(sociealLink.getName()).isEqualTo("GitHub");
         assertThat(sociealLink.getLink()).isEqualTo(link);
     }
@@ -38,11 +37,10 @@ class SociealLinkTest {
     void test2() {
         Link link = Link.create(notification, "https://example.com");
         UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-        SocialLink sociealLink = SocialLink.reconstruct(id, 0, "GitHub", link);
+        SocialLink sociealLink = SocialLink.reconstruct(id, "GitHub", link);
 
         assertThat(sociealLink).isNotNull();
         assertThat(sociealLink.getId()).isEqualTo(id);
-        assertThat(sociealLink.getOrderNo()).isEqualTo(0);
         assertThat(sociealLink.getName()).isEqualTo("GitHub");
         assertThat(sociealLink.getLink()).isEqualTo(link);
     }
@@ -51,7 +49,7 @@ class SociealLinkTest {
     @DisplayName("ソーシャル名を変更する")
     void test3() {
         Link link = Link.create(notification, "https://example.com");
-        SocialLink beforeSociealLink = SocialLink.create(0, "GitHub", link);
+        SocialLink beforeSociealLink = SocialLink.create("GitHub", link);
         SocialLink afterSociealLink = beforeSociealLink.changeName("LinkedIn");
 
         assertThat(afterSociealLink.getName()).isEqualTo("LinkedIn");
@@ -61,7 +59,7 @@ class SociealLinkTest {
     @DisplayName("リンクを変更する")
     void test4() {
         Link beforeLink = Link.create(notification, "https://example.com");
-        SocialLink beforeSociealLink = SocialLink.create(0, "GitHub", beforeLink);
+        SocialLink beforeSociealLink = SocialLink.create("GitHub", beforeLink);
         Link afterLink = Link.create(notification, "https://linkedin.com");
         SocialLink afterSociealLink = beforeSociealLink.changeLink(afterLink);
 
@@ -72,7 +70,7 @@ class SociealLinkTest {
     @DisplayName("ソーシャル名、リンクを変更する")
     void test5() {
         Link beforeLink = Link.create(notification, "https://example.com");
-        SocialLink beforeSociealLink = SocialLink.create(0, "GitHub", beforeLink);
+        SocialLink beforeSociealLink = SocialLink.create("GitHub", beforeLink);
         Link afterLink = Link.create(notification, "https://linkedin.com");
         SocialLink afterSociealLink = beforeSociealLink.changeLink(afterLink).changeName("LinkedIn");
 

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/model/user/UserTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/model/user/UserTest.java
@@ -53,7 +53,6 @@ class UserTest {
 
         User user = User.create(
                 notification,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -88,7 +87,6 @@ class UserTest {
 
         User user = User.create(
                 notification,
-                1,
                 email,
                 null,
                 false,
@@ -121,7 +119,6 @@ class UserTest {
         Notification notification = new Notification();
         User user = User.create(
                 notification,
-                1,
                 null,
                 null,
                 false,
@@ -154,7 +151,6 @@ class UserTest {
         Notification notification = new Notification();
         assertThatThrownBy(() -> User.create(
                 notification,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -170,7 +166,6 @@ class UserTest {
         Email email = Email.create(new Notification(), EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -201,7 +196,6 @@ class UserTest {
     void test6() {
         User user = User.reconstruct(
                 ID,
-                1,
                 null,
                 PASSWORD_HASH,
                 true,
@@ -225,7 +219,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -250,7 +243,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -274,7 +266,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -298,7 +289,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,
@@ -319,7 +309,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -343,7 +332,6 @@ class UserTest {
         // メールアドレスとパスワードが未設定
         User user1 = User.reconstruct(
                 ID,
-                1,
                 null,
                 null,
                 false,
@@ -361,7 +349,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user2 = User.reconstruct(
                 ID,
-                1,
                 email,
                 null,
                 false,
@@ -385,7 +372,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,
@@ -410,7 +396,6 @@ class UserTest {
 
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 null,
                 false,
@@ -436,7 +421,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,
@@ -461,7 +445,6 @@ class UserTest {
 
         User user = User.reconstruct(
                 ID,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -483,7 +466,6 @@ class UserTest {
     void test17() {
         User user = User.reconstruct(
                 ID,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -502,7 +484,6 @@ class UserTest {
     void test18() {
         User user = User.reconstruct(
                 ID,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -525,7 +506,6 @@ class UserTest {
 
         User user = User.reconstruct(
                 ID,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -548,7 +528,6 @@ class UserTest {
     void test20() {
         User user = User.reconstruct(
                 ID,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -569,7 +548,6 @@ class UserTest {
     void test21() {
         User user = User.reconstruct(
                 ID,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -593,7 +571,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -619,7 +596,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.create(
                 notification,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -643,7 +619,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 true,
@@ -663,7 +638,6 @@ class UserTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 ID,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/service/resume/ResumeNameDuplicationCheckServiceTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/service/resume/ResumeNameDuplicationCheckServiceTest.java
@@ -102,7 +102,6 @@ class ResumeNameDuplicationCheckServiceTest {
     private Resume createSampleResume(UUID id, UUID userId, String resumeName) {
         return Resume.reconstruct(
                 id,
-                0,
                 userId,
                 ResumeName.create(notification, resumeName),
                 LocalDate.now(),

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/service/user/UserEmailDuplicationCheckServiceTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/service/user/UserEmailDuplicationCheckServiceTest.java
@@ -49,7 +49,6 @@ class UserEmailDuplicationCheckServiceTest {
         // メールアドレスがnullのユーザーを作成
         User user = User.reconstruct(
                 USER_ID_1,
-                1,
                 null,
                 PASSWORD_HASH,
                 false,
@@ -73,7 +72,6 @@ class UserEmailDuplicationCheckServiceTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 USER_ID_1,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,
@@ -100,7 +98,6 @@ class UserEmailDuplicationCheckServiceTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 USER_ID_1,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,
@@ -113,7 +110,6 @@ class UserEmailDuplicationCheckServiceTest {
         // 同じメールアドレスを持つ別ユーザーを作成（IDが異なる）
         User existingUser = User.reconstruct(
                 USER_ID_2,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,
@@ -140,7 +136,6 @@ class UserEmailDuplicationCheckServiceTest {
         Email email = Email.create(notification, EMAIL);
         User user = User.reconstruct(
                 USER_ID_1,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,
@@ -153,7 +148,6 @@ class UserEmailDuplicationCheckServiceTest {
         // リポジトリから返却されるのは同じユーザー（IDが一致）
         User existingUser = User.reconstruct(
                 USER_ID_1,
-                1,
                 email,
                 PASSWORD_HASH,
                 false,

--- a/backend/src/test/java/com/example/keirekipro/unit/domain/shared/EntityTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/domain/shared/EntityTest.java
@@ -13,56 +13,38 @@ class EntityTest {
 
     // テスト用具体クラス
     private static class TestEntity extends Entity {
-        public TestEntity(int orderNo) {
-            super(orderNo);
+        public TestEntity() {
+            super();
         }
 
-        public TestEntity(UUID id, int orderNo) {
-            super(id, orderNo);
+        public TestEntity(UUID id) {
+            super(id);
         }
     }
 
     @Test
     @DisplayName("新規構築用コンストラクタでインスタンス化する")
     void test1() {
-        TestEntity entity = new TestEntity(1);
-
-        assertThat(entity.getId())
-                .isNotNull();
-        assertThat(entity.getOrderNo())
-                .isEqualTo(1);
+        TestEntity entity = new TestEntity();
+        assertThat(entity.getId()).isNotNull();
     }
 
     @Test
     @DisplayName("再構築用コンストラクタでインスタンス化する")
     void test2() {
         UUID id = UUID.fromString("5af48f3b-468b-4ae0-a065-7d7ac70b37a8");
-        TestEntity entity = new TestEntity(id, 2);
-
-        assertThat(entity.getId())
-                .isEqualTo(id);
-        assertThat(entity.getOrderNo())
-                .isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("並び順を変更する")
-    void test3() {
-        TestEntity entity = new TestEntity(1);
-        entity.changeOrderNo(100);
-
-        assertThat(entity.getOrderNo())
-                .isEqualTo(100);
+        TestEntity entity = new TestEntity(id);
+        assertThat(entity.getId()).isEqualTo(id);
     }
 
     @Test
     @DisplayName("等価チェック")
-    void test4() {
+    void test3() {
         UUID id1 = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         UUID id2 = UUID.fromString("123e4567-e89b-12d3-a456-426614174001");
-        TestEntity entity1 = new TestEntity(id1, 1);
-        TestEntity entity2 = new TestEntity(id1, 1);
-        TestEntity entity3 = new TestEntity(id2, 1);
+        TestEntity entity1 = new TestEntity(id1);
+        TestEntity entity2 = new TestEntity(id1);
+        TestEntity entity3 = new TestEntity(id2);
 
         assertThat(entity1)
                 .isEqualTo(entity2)
@@ -71,12 +53,12 @@ class EntityTest {
 
     @Test
     @DisplayName("ハッシュ値")
-    void test5() {
+    void test4() {
         UUID id1 = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         UUID id2 = UUID.fromString("123e4567-e89b-12d3-a456-426614174001");
-        int entity1HashCode = new TestEntity(id1, 1).hashCode();
-        int entity2HashCode = new TestEntity(id1, 1).hashCode();
-        int entity3HashCode = new TestEntity(id2, 1).hashCode();
+        int entity1HashCode = new TestEntity(id1).hashCode();
+        int entity2HashCode = new TestEntity(id1).hashCode();
+        int entity3HashCode = new TestEntity(id2).hashCode();
 
         assertThat(entity1HashCode)
                 .isEqualTo(entity2HashCode)

--- a/backend/src/test/java/com/example/keirekipro/unit/infrastructure/repository/user/MyBatisUserRepositoryTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/infrastructure/repository/user/MyBatisUserRepositoryTest.java
@@ -110,7 +110,6 @@ class MyBatisUserRepositoryTest {
         // Userエンティティを再構成（プロバイダーはgoogleのみ）
         User entity = User.reconstruct(
                 USER_ID,
-                1,
                 Email.create(new Notification(), EMAIL),
                 PASSWORD,
                 false,

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/LoginUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/LoginUseCaseTest.java
@@ -87,7 +87,6 @@ class LoginUseCaseTest {
         Notification n = new Notification();
         return User.reconstruct(
                 USER_ID,
-                1,
                 Email.create(n, EMAIL),
                 passwordHash,
                 false,

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/OidcLoginUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/OidcLoginUseCaseTest.java
@@ -52,10 +52,13 @@ class OidcLoginUseCaseTest {
         Map<String, AuthProvider> providers = Map.of(
                 PROVIDER_TYPE, AuthProvider.create(notification, PROVIDER_TYPE, PROVIDER_USER_ID));
         User existingUser = User.create(
-                notification, 1,
+                notification,
                 Email.create(notification, EMAIL),
-                null, false, providers,
-                null, USERNAME);
+                null,
+                false,
+                providers,
+                null,
+                USERNAME);
 
         // モックをセットアップ
         when(userRepository.findByProvider(PROVIDER_TYPE, PROVIDER_USER_ID))
@@ -80,10 +83,13 @@ class OidcLoginUseCaseTest {
         Map<String, AuthProvider> existingProviders = Map.of(
                 "github", AuthProvider.create(notification, "github", "github-id"));
         User existingUser = User.create(
-                notification, 1,
+                notification,
                 Email.create(notification, EMAIL),
-                null, false, existingProviders,
-                null, USERNAME);
+                null,
+                false,
+                existingProviders,
+                null,
+                USERNAME);
 
         // モックをセットアップ
         // プロバイダー検索→空、メール検索→ヒット、ID検索→ヒット
@@ -112,9 +118,13 @@ class OidcLoginUseCaseTest {
         Map<String, AuthProvider> providers = Map.of(
                 PROVIDER_TYPE, AuthProvider.create(notification, PROVIDER_TYPE, PROVIDER_USER_ID));
         User existingUser = User.create(
-                notification, 1,
-                null, null, false, providers,
-                null, USERNAME);
+                notification,
+                null,
+                null,
+                false,
+                providers,
+                null,
+                USERNAME);
 
         // モックをセットアップ
         when(userRepository.findByProvider(PROVIDER_TYPE, PROVIDER_USER_ID))
@@ -205,10 +215,13 @@ class OidcLoginUseCaseTest {
         Map<String, AuthProvider> providers = Map.of(
                 PROVIDER_TYPE, AuthProvider.create(notification, PROVIDER_TYPE, PROVIDER_USER_ID));
         User existingUser = User.create(
-                notification, 1,
+                notification,
                 Email.create(notification, EMAIL),
-                null, false, providers,
-                null, USERNAME);
+                null,
+                false,
+                providers,
+                null,
+                USERNAME);
 
         // モックをセットアップ
         when(userRepository.findByProvider(PROVIDER_TYPE, PROVIDER_USER_ID))

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/RequestPasswordResetUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/RequestPasswordResetUseCaseTest.java
@@ -64,7 +64,6 @@ class RequestPasswordResetUseCaseTest {
         Notification notification = new Notification();
         User user = User.reconstruct(
                 USER_ID,
-                1,
                 Email.create(notification, EMAIL),
                 "hashedPassword",
                 false,

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/ResetPasswordUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/ResetPasswordUseCaseTest.java
@@ -52,7 +52,7 @@ class ResetPasswordUseCaseTest {
     @DisplayName("パスワードリセットが正常に完了する")
     void test1() {
         // データ準備
-        User user = User.reconstruct(USER_ID, 1, null, "oldHash", false, null, null, USERNAME, null, null);
+        User user = User.reconstruct(USER_ID, null, "oldHash", false, null, null, USERNAME, null, null);
 
         // モックをセットアップ
         when(redisClient.getValue(REDIS_KEY, String.class)).thenReturn(Optional.of(USER_ID.toString()));

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/UserRegistrationUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/auth/UserRegistrationUseCaseTest.java
@@ -79,7 +79,7 @@ class UserRegistrationUseCaseTest {
         // データ準備
         UserRegistrationRequest request = new UserRegistrationRequest(EMAIL, USERNAME, PASSWORD, CONFIRM_PASSWORD);
         Notification notification = new Notification();
-        User existing = User.create(notification, 1, Email.create(notification, EMAIL), HASHED_PASSWORD,
+        User existing = User.create(notification, Email.create(notification, EMAIL), HASHED_PASSWORD,
                 false, null, null, USERNAME);
 
         // モックをセットアップ

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/user/ChangePasswordUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/user/ChangePasswordUseCaseTest.java
@@ -55,7 +55,7 @@ class ChangePasswordUseCaseTest {
 
         // テスト用ユーザー生成
         Notification notification = new Notification();
-        User user = User.create(notification, 1, Email.create(notification, "test@keirekipro.click"),
+        User user = User.create(notification, Email.create(notification, "test@keirekipro.click"),
                 HASHED_CURRENT_PASSWORD, false, Collections.emptyMap(), null, "tester");
 
         // モックをセットアップ
@@ -100,7 +100,7 @@ class ChangePasswordUseCaseTest {
 
         // テスト用ユーザー生成
         Notification notification = new Notification();
-        User user = User.create(notification, 1, Email.create(notification, "test@keirekipro.click"),
+        User user = User.create(notification, Email.create(notification, "test@keirekipro.click"),
                 HASHED_CURRENT_PASSWORD, false, Collections.emptyMap(), null, "tester");
 
         // モックをセットアップ
@@ -128,7 +128,7 @@ class ChangePasswordUseCaseTest {
 
         // テスト用ユーザー生成
         Notification notification = new Notification();
-        User user = User.create(notification, 1, Email.create(notification, "test@keirekipro.click"),
+        User user = User.create(notification, Email.create(notification, "test@keirekipro.click"),
                 HASHED_CURRENT_PASSWORD, false, Collections.emptyMap(), null, "tester");
 
         // モックをセットアップ
@@ -158,7 +158,7 @@ class ChangePasswordUseCaseTest {
 
         // テスト用ユーザー生成
         Notification notification = new Notification();
-        User user = User.create(notification, 1, Email.create(notification, "test@keirekipro.click"),
+        User user = User.create(notification, Email.create(notification, "test@keirekipro.click"),
                 HASHED_CURRENT_PASSWORD, false, Collections.emptyMap(), null, "tester");
 
         // モックをセットアップ

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/user/DeleteUserUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/user/DeleteUserUseCaseTest.java
@@ -44,7 +44,7 @@ class DeleteUserUseCaseTest {
     @DisplayName("ユーザー削除が正常に完了する")
     void test1() {
         Notification notification = new Notification();
-        User user = User.create(notification, 1, Email.create(notification, "test@example.com"),
+        User user = User.create(notification, Email.create(notification, "test@example.com"),
                 "passwordHash", false, null, null, "test-user");
 
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/user/GetUserInfoUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/user/GetUserInfoUseCaseTest.java
@@ -63,7 +63,6 @@ class GetUserInfoUseCaseTest {
                 PROVIDER_USER_ID_VALUE);
         User user = User.reconstruct(
                 USER_ID,
-                1,
                 Email.create(new Notification(), EMAIL),
                 null,
                 false,
@@ -108,7 +107,6 @@ class GetUserInfoUseCaseTest {
                 PROVIDER_USER_ID_VALUE);
         User user = User.reconstruct(
                 USER_ID,
-                1,
                 Email.create(new Notification(), EMAIL),
                 null,
                 false,

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/user/RemoveAuthProviderUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/user/RemoveAuthProviderUseCaseTest.java
@@ -47,7 +47,6 @@ class RemoveAuthProviderUseCaseTest {
         AuthProvider authProvider = AuthProvider.create(notification, PROVIDER, "providerUserId");
         User user = User.reconstruct(
                 USER_ID,
-                1,
                 Email.create(notification, "test@example.com"),
                 "hashedPassword",
                 false,

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/user/SetEmailAndPasswordUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/user/SetEmailAndPasswordUseCaseTest.java
@@ -53,7 +53,7 @@ class SetEmailAndPasswordUseCaseTest {
     @DisplayName("パスワードのみを設定する")
     void test1() {
         // モックをセットアップ
-        User user = User.reconstruct(USER_ID, 1, Email.create(new Notification(), EMAIL), null, false, Map.of(), null,
+        User user = User.reconstruct(USER_ID, Email.create(new Notification(), EMAIL), null, false, Map.of(), null,
                 USERNAME, null, null);
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(passwordEncoder.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
@@ -69,7 +69,7 @@ class SetEmailAndPasswordUseCaseTest {
     @DisplayName("メールアドレスとパスワードを設定する")
     void test2() {
         // モックをセットアップ
-        User user = User.reconstruct(USER_ID, 1, null, null, false, Map.of(), null, USERNAME, null, null);
+        User user = User.reconstruct(USER_ID, null, null, false, Map.of(), null, USERNAME, null, null);
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(passwordEncoder.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
 

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/user/UpdateUserInfoUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/user/UpdateUserInfoUseCaseTest.java
@@ -80,7 +80,7 @@ class UpdateUserInfoUseCaseTest {
         Notification notification = new Notification();
         AuthProvider authProvider = AuthProvider.create(notification, "google", "gid-1");
         User existingUser = User.reconstruct(
-                USER_ID, 1,
+                USER_ID,
                 Email.create(notification, EMAIL),
                 PASSWORD_HASH, false,
                 Map.of("google", authProvider),
@@ -236,7 +236,7 @@ class UpdateUserInfoUseCaseTest {
 
         Notification notification = new Notification();
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(
-                User.reconstruct(USER_ID, 1, Email.create(notification, "a@b.com"),
+                User.reconstruct(USER_ID, Email.create(notification, "a@b.com"),
                         "pw", false, Map.of(), null, "", LocalDateTime.now(), LocalDateTime.now())));
         try (MockedStatic<FileUtil> util = mockStatic(FileUtil.class)) {
             util.when(() -> FileUtil.isMimeTypeValid(any(), anyList())).thenReturn(true);

--- a/doc/DB設計/ER図.pu
+++ b/doc/DB設計/ER図.pu
@@ -33,7 +33,6 @@ entity "職務経歴書(resumes)" as Resumes {
     auto_save_enabled : <color:#1E90FF>BOOLEAN</color> <color:#32CD32>[NOT NULL]</color> -- 自動保存有効フラグ
     created_at : <color:#1E90FF>TIMESTAMP(6)</color> <color:#32CD32>[NOT NULL]</color> -- 作成日時
     updated_at : <color:#1E90FF>TIMESTAMP(6)</color> <color:#32CD32>[NOT NULL]</color> -- 更新日時
-    order_no : <color:#1E90FF>INTEGER</color> <color:#32CD32>[NOT NULL]</color> -- 並び順
 }
 
 entity "職歴(careers)" as Careers {
@@ -44,7 +43,6 @@ entity "職歴(careers)" as Careers {
     start_date : <color:#1E90FF>DATE</color> <color:#32CD32>[NOT NULL]</color> -- 入社年月
     end_date : <color:#1E90FF>DATE</color> <color:#32CD32>[NOT NULL]</color> -- 退職年月
     is_active : <color:#1E90FF>BOOLEAN</color> <color:#32CD32>[NOT NULL]</color> -- 在籍中フラグ
-    order_no : <color:#1E90FF>INTEGER</color> <color:#32CD32>[NOT NULL]</color> -- 並び順
 }
 
 entity "プロジェクト(projects)" as Projects {
@@ -87,7 +85,6 @@ entity "プロジェクト(projects)" as Projects {
     documentation_tools : <color:#1E90FF>TEXT[]</color> -- ドキュメント
     api_development_tools : <color:#1E90FF>TEXT[]</color> -- API開発
     design_tools : <color:#1E90FF>TEXT[]</color> -- デザイン
-    order_no : <color:#1E90FF>INTEGER</color> <color:#32CD32>[NOT NULL]</color> -- 並び順
 }
 
 entity "資格(certifications)" as Certifications {
@@ -96,7 +93,6 @@ entity "資格(certifications)" as Certifications {
     resume_id : <color:#1E90FF>UUID</color> <color:#32CD32>[NOT NULL]</color> -- 職務経歴書ID
     name : <color:#1E90FF>VARCHAR(255)</color> -- 資格名
     date : <color:#1E90FF>DATE</color> -- 取得日
-    order_no : <color:#1E90FF>INTEGER</color> <color:#32CD32>[NOT NULL]</color> -- 並び順
 }
 
 entity "ポートフォリオ(portfolios)" as Portfolios {
@@ -107,7 +103,6 @@ entity "ポートフォリオ(portfolios)" as Portfolios {
     overview : <color:#1E90FF>VARCHAR(255)</color> -- 概要
     tech_stack : <color:#1E90FF>TEXT</color> -- 技術スタック
     link : <color:#1E90FF>VARCHAR(255)</color> -- リンク
-    order_no : <color:#1E90FF>INTEGER</color> <color:#32CD32>[NOT NULL]</color> -- 並び順
 }
 
 entity "ソーシャルリンク(social_links)" as SocialLinks {
@@ -116,7 +111,6 @@ entity "ソーシャルリンク(social_links)" as SocialLinks {
     resume_id : <color:#1E90FF>UUID</color> <color:#32CD32>[NOT NULL]</color> -- 職務経歴書ID
     name : <color:#1E90FF>VARCHAR(255)</color> -- ソーシャルリンク名
     link : <color:#1E90FF>VARCHAR(255)</color> -- リンク
-    order_no : <color:#1E90FF>INTEGER</color> <color:#32CD32>[NOT NULL]</color> -- 並び順
 }
 
 entity "自己PR(self_promotions)" as SelfPromotions {
@@ -125,7 +119,6 @@ entity "自己PR(self_promotions)" as SelfPromotions {
     resume_id : <color:#1E90FF>UUID</color> <color:#32CD32>[NOT NULL]</color> -- 職務経歴書ID
     title : <color:#1E90FF>VARCHAR(255)</color> -- タイトル
     content : <color:#1E90FF>TEXT</color> -- コンテンツ
-    order_no : <color:#1E90FF>INTEGER</color> <color:#32CD32>[NOT NULL]</color> -- 並び順
 }
 
 entity "技術スタックマスタ(tech_stack_mst)" as TechStackMst {

--- a/doc/モデル図/ドメインモデル.pu
+++ b/doc/モデル図/ドメインモデル.pu
@@ -12,7 +12,6 @@ package "職務経歴書集約(ResumeAggregation)" as ResumeAggregation {
         ・上記理由から、UIやDB都合の形式チェックや文字数制限バリデーションはプレゼンテーション層で行うものとする。
         【共通ルール】
         ・idはUUIDによって生成された文字列とする。
-        ・orderNoは各項目をソートするために使用するため、各リスト内でユニークでなければならない。
     end note
 
     ' -------------------------------- エンティティの定義 --------------------------------
@@ -27,7 +26,6 @@ package "職務経歴書集約(ResumeAggregation)" as ResumeAggregation {
     class "職歴(Career)" as Career << (E,green) Entity >> {
         - 職歴ID: id
         - 会社名: companyName
-        - 並び順: orderNo
     }
 
     class "プロジェクト(Project)" as Project << (E,green) Entity >> {
@@ -39,14 +37,12 @@ package "職務経歴書集約(ResumeAggregation)" as ResumeAggregation {
         - 役割: role
         - 成果: achievement
         - 作業工程: process
-        - 並び順: orderNo
     }
 
     class "資格(Certification)" as Certification << (E,green) Entity >> {
         - 資格ID: id
         - 資格名: name
         - 取得年月: date
-        - 並び順: orderNo
     }
 
     class "ポートフォリオ(Portfolio)" as Portfolio << (E,green) Entity >> {
@@ -54,20 +50,17 @@ package "職務経歴書集約(ResumeAggregation)" as ResumeAggregation {
         - ポートフォリオ名: name
         - ポートフォリオ概要: overview
         - 技術スタック: techStack
-        - 並び順: orderNo
     }
 
     class "ソーシャルリンク(SocialLink)" as SocialLink << (E,green) Entity >> {
         - ソーシャルリンクID: id
         - ソーシャル名: name
-        - 並び順: orderNo
     }
 
     class "自己PR(SelfPromotion)" as SelfPromotion << (E,green) Entity >> {
         - 自己PRID: id
         - タイトル: title
         - コンテンツ: content
-        - 並び順: orderNo
     }
 
     ' -------------------------------- 値オブジェクトの定義 --------------------------------


### PR DESCRIPTION
Changes:
    - Userエンティティ及びResumeエンティティからorderNoを削除するために基底クラスEntity.javaからorderNoを削除
    - 上記に伴う各種コードの修正
    - DDL、ER図、ドメインモデルの修正

Reason:
不要な要素であるため

BREAKING CHANGE: N/A
Related: N/A
Refs: #27