### PR TITLE
ci: npmのライフサイクルスクリプトを無効化

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
           node-version: '22.11.0'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Run Format
         run: npm run format

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
Changes:
- .npmrcを追加しignore-scripts=trueを設定
- GitHub Actionsでnpm ciに--ignore-scriptsを付与

Reason:
依存導入時のpreinstall/postinstall実行を遮断し感染を防止

BREAKING CHANGE: N/A
Related: https://www.proactivedefense.jp/blog/blog-training/post-7240
Refs: N/A