### PR TITLE
fix: プロフィール画像保存時の処理を修正

### DIFF
--- a/backend/src/main/java/com/example/keirekipro/shared/utils/FileUtil.java
+++ b/backend/src/main/java/com/example/keirekipro/shared/utils/FileUtil.java
@@ -88,4 +88,22 @@ public class FileUtil {
         }
         return name.length() > 255 ? name.substring(0, 255) : name;
     }
+
+    /**
+     * 拡張子を取得する
+     *
+     * @param file 対象ファイル
+     * @return 拡張子（例: "png"）。取得できない場合は空文字
+     */
+    public static String getExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null) {
+            return "";
+        }
+        int lastDot = originalFilename.lastIndexOf(".");
+        if (lastDot == -1 || lastDot == originalFilename.length() - 1) {
+            return "";
+        }
+        return originalFilename.substring(lastDot + 1).toLowerCase();
+    }
 }

--- a/backend/src/main/java/com/example/keirekipro/usecase/user/UpdateUserInfoUseCase.java
+++ b/backend/src/main/java/com/example/keirekipro/usecase/user/UpdateUserInfoUseCase.java
@@ -71,11 +71,16 @@ public class UpdateUserInfoUseCase {
         String imageKey = null;
         if (profileImage != null && !profileImage.isEmpty()) {
             try {
+                String originalFilename = profileImage.getOriginalFilename();
                 StoredObject object = new StoredObject(
                         profileImage.getBytes(),
                         profileImage.getContentType(),
-                        profileImage.getOriginalFilename());
-                imageKey = objectStore.put(object, "/profile/image/");
+                        originalFilename);
+
+                String extension = FileUtil.getExtension(profileImage);
+                String fileName = userId.toString() + (extension.isBlank() ? "" : "." + extension);
+
+                imageKey = objectStore.putAs(object, "/profile/image/", fileName);
             } catch (IOException e) {
                 throw new UseCaseException("プロフィール画像のアップロードに失敗しました。しばらく時間を置いてから再度お試しください。");
             }

--- a/backend/src/test/java/com/example/keirekipro/unit/shared/utils/FileUtilTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/shared/utils/FileUtilTest.java
@@ -331,4 +331,45 @@ class FileUtilTest {
         // 検証
         assertThat(result).isEqualTo("filename");
     }
+
+    @Test
+    @DisplayName("getExtension_拡張子を小文字で返す")
+    public void test22() {
+        MockMultipartFile file = new MockMultipartFile(
+                "testFile",
+                "test.PNG",
+                "image/png",
+                "dummy".getBytes());
+
+        // 実行
+        String result = FileUtil.getExtension(file);
+
+        // 検証
+        assertThat(result).isEqualTo("png");
+    }
+
+    @Test
+    @DisplayName("getExtension_ファイル名がnullの場合は空文字を返す")
+    public void test23() {
+        when(mockFile.getOriginalFilename()).thenReturn(null);
+
+        // 実行
+        String result = FileUtil.getExtension(mockFile);
+
+        // 検証
+        assertThat(result).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("getExtension_拡張子がない場合は空文字を返す")
+    public void test24() {
+        when(mockFile.getOriginalFilename()).thenReturn("testfile");
+
+        // 実行
+        String result = FileUtil.getExtension(mockFile);
+
+        // 検証
+        assertThat(result).isEqualTo("");
+    }
+
 }


### PR DESCRIPTION
Changes:
プロフィール画像のファイル名をuserIdで保存するように修正

Reason:
不要な画像ファイルがバケット内に蓄積するため

BREAKING CHANGE: N/A
Related: N/A
Refs: N/A