### PR TITLE
fix: GitHub ActionsのNode.jsバージョン指定をマイナーバージョン追従に変更

### DIFF
--- a/.github/workflows/frontend-deploy.yaml
+++ b/.github/workflows/frontend-deploy.yaml
@@ -24,7 +24,7 @@ permissions:
 env:
   AWS_REGION: ap-northeast-1
   S3_BUCKET: keirekipro-frontend
-  NODE_VERSION: '22.11.0'
+  NODE_VERSION: '22'
 
 jobs:
   deploy:
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
 
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund
@@ -78,11 +79,11 @@ jobs:
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "index.html" \
             --exclude "*.json"
-          
+
           # index.htmlは短いキャッシュを設定
           aws s3 cp dist/index.html s3://${{ steps.vars.outputs.s3_bucket_name }}/index.html \
             --cache-control "public, max-age=0, must-revalidate"
-          
+
           # JSONファイル（manifest.jsonなど）がある場合
           find dist -name "*.json" -exec aws s3 cp {} s3://${{ steps.vars.outputs.s3_bucket_name }}/ \
             --cache-control "public, max-age=0, must-revalidate" \; 2>/dev/null || true


### PR DESCRIPTION
Changes:
- .github/workflows配下のNODE_VERSIONおよびsetup-nodeのnode-version指定を'22.11.0'から'22'に変更
- setup-nodeにcheck-latest: trueを追加し、Runnerプリインストール版ではなく公式リポジトリから最新パッチバージョンを取得するよう設定

Reason:
Node.js 22.11.0には複数の未パッチ脆弱性(CVE-2025-55131(CVSS 8.1)、CVE-2025-55130(CVSS 7.7)、CVE-2025-59465(CVSS 7.5)等)が存在する。 パッチバージョンを固定すると都度手動更新が必要になりセキュリティパッチへの追従が遅れるため、メジャーバージョンのみ指定し最新パッチを自動取得する方式に変更する。 node-version: '22'のみではRunnerにプリインストールされた古いパッチバージョンが使われる可能性があるため、check-latest: trueを併用して公式リポジトリから最新を取得する。

BREAKING CHANGE: N/A
Related: https://nodejs.org/en/blog/vulnerability/december-2025-security-releases R