### PR TITLE
fix: GitHub ActionsのCIのNode.jsバージョン指定をマイナーバージョン追従に変更

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Use Node.js 22.11.0
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.11.0'
+          node-version: '22'
+          check-latest: true
 
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund


### PR DESCRIPTION
Changes:

Reason:

BREAKING CHANGE: N/A
Related: N/A
Refs: N/A