### PR TITLE
test: hookテストのVitest警告を解消

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,196 +1,218 @@
-# AGENTS.md
+## プロジェクト概要
 
-## Project overview
+KeirekiPro は、エンジニア向けの履歴書・職務経歴書を作成、管理するフルスタック Web アプリケーションです。
 
-KeirekiPro is a full-stack web application for engineers to create and manage resumes and career-history documents.
+このアプリケーションは、案件経歴、スキル、PDF/Markdown エクスポート、プロフィール画像、認証、バックアップ/リストア、AWS 上のインフラ管理を扱います。
 
-The application supports detailed project and skill records, PDF/Markdown export, profile images, authentication, backup/restore, and infrastructure managed on AWS.
+## リポジトリ構成
 
-## Repository map
+- `backend` - Spring Boot バックエンド API
+- `frontend` - React/Vite フロントエンド SPA
+- `terraform` - AWS インフラ IaC
+- `docker` と `compose.yaml` - Docker / devcontainer 設定
+- `.github/workflows` - GitHub Actions CI/CD workflow
+- `doc` - アーキテクチャおよびプロジェクト資料
 
-- `backend` - Spring Boot backend API
-- `frontend` - React/Vite frontend SPA
-- `terraform` - AWS infrastructure as code
-- `docker` and `compose.yaml` - Docker and devcontainer configuration
-- `.github/workflows` - GitHub Actions CI/CD workflows
-- `doc` - architecture and project documentation
+エージェントは全体の文脈把握のためにリポジトリ全体を確認してよいです。
 
-Agents may inspect the whole repository to understand context, but changes must stay limited to the requested task scope.
+ただし、変更は依頼された作業範囲に限定してください。
 
-## Core rules
+## 基本ルール
 
-- Do not modify unrelated files.
-- Do not remove existing comments unless the task explicitly requires it.
-- Do not rewrite files only for style.
-- Do not introduce new libraries, frameworks, tools, or runtime dependencies unless explicitly requested.
-- Do not change public behavior, API contracts, database schema, infrastructure settings, CI/CD behavior, or deployment behavior unless explicitly requested.
-- Do not commit, push, merge, deploy, or run destructive commands unless explicitly requested.
-- Verify the final diff before reporting completion.
+- 依頼範囲外のファイルを変更しないでください。
+- 明示的に求められていない既存コメントを削除しないでください。
+- スタイル調整だけを目的にファイル全体を書き換えないでください。
+- 明示的に求められていない新しいライブラリ、フレームワーク、ツール、ランタイム依存を追加しないでください。
+- 明示的に求められていない public behavior、API contract、DB schema、インフラ設定、CI/CD 挙動、デプロイ挙動を変更しないでください。
+- 明示的に求められていない commit、push、merge、deploy、破壊的コマンドを実行しないでください。
+- 完了報告前に、必ず最終 diff を確認してください。
 
 ## Git
 
-Run Git commands from the repository root.
+Git 操作は、ホスト OS のリポジトリルートで実行してください。
+
+作業開始前に、必ず作業内容に対応するブランチを作成してから変更してください。
+ブランチ名は `<type>/<short-description>` 形式を基本とし、`type` は変更内容に応じて `feature`、`bugfix`、`hotfix`、`refactor`、`docs`、`test`、`chore` から選択してください。
+`short-description` は英小文字、数字、ハイフンで構成し、作業内容を簡潔に表す kebab-case にしてください。
 
 ```bash
-git status
+git switch -c docs/update-agent-guidelines
+```
+
+```bash
+git status --short
 git diff --stat
 git diff
 ```
 
-Before reporting completion, confirm that only intended files changed.
+完了報告前に、意図したファイルだけが変更されていることを確認してください。
+
+Git status を確認できない場合は、完了報告をしないでください。
+
+## Docker Compose 経由のコマンド実行
+
+Codex はホスト OS のリポジトリルートで動かし、言語・ツール固有のコマンドは Docker Compose サービス内で実行してください。
+
+backend コマンドは `backend` サービスの `/home/spring/app` で実行します。
+
+frontend コマンドは `frontend` サービスの `/home/node/app` で、原則 `node` ユーザーとして実行します。
+
+terraform コマンドは `terraform` サービスの `/workspace` で実行します。
 
 ## Backend
 
-The backend uses Java 21, Spring Boot, Gradle, MyBatis, Flyway, Spring Security, JWT, JUnit 5, Mockito, AssertJ, Testcontainers, Spotless, Checkstyle, JaCoCo, and SpotBugs.
+バックエンドは Java 21、Spring Boot、Gradle、MyBatis、Flyway、Spring Security、JWT、JUnit 5、Mockito、AssertJ、Testcontainers、Spotless、Checkstyle、JaCoCo、SpotBugs を使用します。
 
-In a backend devcontainer, the workspace is already the backend working directory. Do not run `cd backend` unless the current shell is at the repository root.
-
-Backend quality gates include formatting, Checkstyle, tests, JaCoCo, and SpotBugs.
-
-Before completing backend changes, run:
+バックエンド変更後は、完了前に次を実行してください。
 
 ```bash
-./gradlew spotlessApply
-./gradlew check
+docker compose exec -w /home/spring/app backend ./gradlew spotlessApply
+docker compose exec -w /home/spring/app backend ./gradlew check
 ```
 
-Use narrower commands only while diagnosing failures:
+障害調査中のみ、必要に応じて狭い範囲のコマンドを使用してください。
 
 ```bash
-./gradlew test
-./gradlew spotlessCheck
-./gradlew checkstyleMain checkstyleTest
-./gradlew spotbugsMain spotbugsTest
-./gradlew jacocoTestReport
+docker compose exec -w /home/spring/app backend ./gradlew test
+docker compose exec -w /home/spring/app backend ./gradlew spotlessCheck
+docker compose exec -w /home/spring/app backend ./gradlew checkstyleMain checkstyleTest
+docker compose exec -w /home/spring/app backend ./gradlew spotbugsMain spotbugsTest
+docker compose exec -w /home/spring/app backend ./gradlew jacocoTestReport
 ```
 
-Backend design facts:
+### Backend 設計ルール
 
-- The backend follows Onion Architecture, DDD, and CQRS.
-- Domain logic belongs in `domain`.
-- Use case orchestration belongs in `usecase`.
-- Query interfaces belong in `usecase/query`; query implementations belong in `infrastructure/query`.
-- Framework, database, storage, and external service concerns belong in `presentation` or `infrastructure`.
-- Controllers use one public `handle()` method per class.
-- Use cases use one public `execute()` method per class.
-- Domain model methods may return updated instances. Do not ignore those return values.
-- SpotBugs warnings should be fixed in code when they indicate real correctness or design issues. Use exclusions only for confirmed tool/framework noise.
+- バックエンドは Onion Architecture、DDD、CQRS に従います。
+- ドメインロジックは `domain` に配置してください。
+- ユースケースの orchestration は `usecase` に配置してください。
+- Query interface は `usecase/query` に配置してください。
+- Query implementation は `infrastructure/query` に配置してください。
+- フレームワーク、DB、storage、外部サービスに関する処理は `presentation` または `infrastructure` に配置してください。
+- Controller の public method は、原則として各 class に `handle()` 1 つだけにしてください。
+- UseCase の public method は、原則として各 class に `execute()` 1 つだけにしてください。
+- Domain model の method が更新後 instance を返す場合、その戻り値を無視しないでください。
+- SpotBugs warning は、実際の正しさや設計上の問題を示している場合はコードで修正してください。
+- SpotBugs exclusion は、ツールまたは framework 由来の誤検知と確認できた場合だけ使用してください。
 
 ## Frontend
 
-The frontend uses TypeScript, React 18, Vite, React Router v7, MUI, Zustand, TanStack Query, ESLint, Prettier, Vitest, and Testing Library.
+フロントエンドは TypeScript、React 18、Vite、React Router v7、MUI、Zustand、TanStack Query、ESLint、Prettier、Vitest、Testing Library を使用します。
 
-In a frontend devcontainer, the workspace is already the frontend working directory. Do not run `cd frontend` unless the current shell is at the repository root.
-
-Before completing frontend changes, run:
+フロントエンド変更後は、完了前に次を実行してください。
 
 ```bash
-npm run format
-npm run lint
-npm test
-npm run coverage
+docker compose exec -u node -w /home/node/app frontend npm run format
+docker compose exec -u node -w /home/node/app frontend npm run lint
+docker compose exec -u node -w /home/node/app frontend npm test
+docker compose exec -u node -w /home/node/app frontend npm run coverage
 ```
 
-Run a production build when the task affects build output, routing, environment variables, or deployment behavior:
+`npm run coverage` はフロントエンド品質ゲートとして必須です。
+
+`npm run build` で代替しないでください。
+
+ビルド出力、routing、環境変数、デプロイ挙動に影響する変更の場合のみ、production build を実行してください。
 
 ```bash
-npm run build
+docker compose exec -u node -w /home/node/app frontend npm run build
 ```
 
-Frontend design facts:
+フロントエンドコマンドは、`dist/` や `test-results/` などの ignored artifact を生成する場合があります。
 
-- The frontend follows a feature-based structure based on Bulletproof React.
-- Feature code belongs in `src/features/{feature-name}`.
-- Shared UI belongs in `src/components`.
-- Shared hooks belong in `src/hooks`.
-- Global state belongs in `src/stores`.
-- API access and query logic should follow existing feature conventions.
-- Formatting is checked by Prettier.
-- Linting is checked by ESLint.
-- Tests and coverage are checked by Vitest.
+フロントエンドコマンド実行後は、必ずホスト OS のリポジトリルートで最終 diff を確認してください。
+
+```bash
+git status --short
+git diff --stat
+```
+
+### Frontend 設計ルール
+
+- フロントエンドは Bulletproof React を参考にした feature-based structure に従います。
+- Feature code は `src/features/{feature-name}` に配置してください。
+- Shared UI は `src/components` に配置してください。
+- Shared hook は `src/hooks` に配置してください。
+- Global state は `src/stores` に配置してください。
+- API access と query logic は、既存 feature の規約に合わせてください。
+- formatting は Prettier で確認されます。
+- linting は ESLint で確認されます。
+- test と coverage は Vitest で確認されます。
 
 ## Terraform
 
-In a terraform devcontainer, the workspace is already the terraform working directory. Do not run `cd terraform` unless the current shell is at the repository root.
-
-Before completing Terraform changes, run the relevant checks:
+Terraform 変更後は、完了前に関連する検証を実行してください。
 
 ```bash
-terraform fmt -check -recursive
-terraform validate
-tflint --recursive
-checkov -d .
+docker compose exec -w /workspace terraform terraform fmt -check -recursive
+docker compose exec -w /workspace terraform terraform validate
+docker compose exec -w /workspace terraform tflint --recursive
+docker compose exec -w /workspace terraform checkov -d .
 ```
 
-Terraform rules:
+### Terraform ルール
 
-- Do not modify production-impacting infrastructure unless explicitly requested.
-- Do not change resource names, state-sensitive identifiers, backend settings, or provider settings unless explicitly requested.
-- Do not commit secrets, credentials, `.tfvars` containing secrets, state files, or generated plan files.
-- Report any resource replacement risk.
+- 明示的に求められていない production-impacting なインフラ変更をしないでください。
+- 明示的に求められていない resource name、state-sensitive identifier、backend setting、provider setting を変更しないでください。
+- secret、credential、secret を含む `.tfvars`、state file、生成された plan file を commit しないでください。
+- resource replacement のリスクがある場合は報告してください。
 
-## Docker and devcontainers
+## Docker と devcontainer
 
-Docker and devcontainer files are under:
+Docker と devcontainer 関連ファイルは次にあります。
 
 ```text
 docker
 compose.yaml
 ```
 
-Rules:
+### Docker / devcontainer ルール
 
-- Backend, frontend, and terraform containers must be able to inspect the repository root.
-- Each container should keep its primary working directory aligned with its task area.
-- Do not change container users, working directories, mounted paths, service names, or installed packages unless explicitly requested.
+- backend、frontend、terraform container は、リポジトリルートを確認できる状態を維持してください。
+- 各 container の primary working directory は、それぞれの作業領域に合わせて維持してください。
+- 明示的に求められていない container user、working directory、mount path、service name、installed package の変更をしないでください。
+- Codex の主 workspace を devcontainer の component-level workspace にしないでください。
+- Codex の主 workspace は、ホスト OS のリポジトリルートにしてください。
 
 ## CI/CD
 
-GitHub Actions workflows are under:
+GitHub Actions workflow は次にあります。
 
 ```text
 .github/workflows
 ```
 
-CI/CD facts:
+### CI/CD の事実
 
-- Pull requests run checks only.
-- Deploy workflows run after the relevant CI job succeeds on `main`, or by explicit manual dispatch.
-- Backend CI runs `./gradlew check`.
-- Frontend CI runs format, lint, test, and coverage.
-- Backend deploy builds and pushes a Docker image to ECR and deploys to ECS Fargate.
-- Frontend deploy builds the SPA, syncs to S3, and invalidates CloudFront.
+- Pull request では check のみ実行します。
+- Deploy workflow は、`main` への push 後に該当 CI job が成功した場合、または明示的な manual dispatch の場合に実行します。
+- Backend CI は `./gradlew check` を実行します。
+- Frontend CI は format、lint、test、coverage を実行します。
+- Backend deploy は Docker image を ECR に push し、ECS Fargate に deploy します。
+- Frontend deploy は SPA を build し、S3 に sync し、CloudFront cache を invalidate します。
 
-CI/CD rules:
+### CI/CD ルール
 
-- Do not change AWS roles, regions, service names, S3 buckets, CloudFront distributions, ECR repositories, ECS services, or deployment triggers unless explicitly requested.
-- Do not make deploy workflows run directly and independently on `push` if that bypasses CI success.
+- 明示的に求められていない AWS role、region、service name、S3 bucket、CloudFront distribution、ECR repository、ECS service、deployment trigger を変更しないでください。
+- CI 成功を bypass する形で、deploy workflow を `push` から直接・独立して実行するように変更しないでください。
 
 ## Documentation
 
-Documentation is under:
+Documentation は次にあります。
 
 ```text
 doc
 ```
 
-Rules:
+### Documentation ルール
 
-- Update documentation only when the requested change affects documented behavior, setup, architecture, commands, or operations.
-- Do not rewrite documentation broadly when a targeted update is sufficient.
-- Prefer pointers to authoritative files over copied code snippets.
+- 依頼された変更が、文書化済みの挙動、setup、architecture、command、operation に影響する場合のみ documentation を更新してください。
+- 広範囲に documentation を書き換えないでください。
+- 必要な箇所だけを対象にしてください。
+- コード断片を複製するより、authoritative file への参照を優先してください。
 
-## Hooks and skills
+## 完了報告
 
-No repository-level hooks, Claude Code hooks, custom skills, or subagents are required at this time.
-
-Quality gates are represented by project commands and CI workflows. Agents should run the relevant commands directly instead of relying on tool-specific automation.
-
-Reconsider hooks or skills only if the same manual agent workflow is repeated frequently and cannot be represented clearly by project commands or CI.
-
-## Completion report
-
-When reporting completion, use this format:
+完了報告は次の形式で行ってください。
 
 ```text
 Changed files:
@@ -204,4 +226,19 @@ Notes:
 - ...
 ```
 
-If a command fails and the failure is within scope, fix it. If it is outside scope, report the exact command and relevant output.
+変更領域に必要な品質ゲート command は、すべて command result に含めてください。
+
+command が失敗し、その失敗が作業範囲内であれば修正してください。
+
+command が失敗し、その失敗が作業範囲外であれば、実行した command と関連 output を報告してください。
+
+完了報告には、ルートにある `.commit_template` を参照して作成したコミットメッセージも含めてください。
+
+完了報告前に、必ずホスト OS のリポジトリルートで次を確認してください。
+
+```bash
+git status --short
+git diff --stat
+```
+
+最終 diff の確認ができていない場合は、完了報告をしないでください。

--- a/frontend/src/features/auth/hooks/__tests__/useAuthorizeOidc.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useAuthorizeOidc.test.ts
@@ -5,13 +5,13 @@ vi.mock("@/lib", () => ({
     publicApiClient: { get: vi.fn() },
 }));
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { useAuthorizeOidc } from "@/features/auth";
 import { publicApiClient } from "@/lib";
 import { useErrorMessageStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 import type { AuthProvider } from "@/types";
 
 describe("useAuthorizeOidc", () => {
@@ -41,9 +41,7 @@ describe("useAuthorizeOidc", () => {
         const { result } = renderHook(() => useAuthorizeOidc(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate("github" as AuthProvider);
-        });
+        mutateHook(result, "github" as AuthProvider);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/auth/hooks/__tests__/useLogin.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useLogin.test.ts
@@ -19,7 +19,7 @@ vi.mock("react-router", async () => {
     };
 });
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { paths } from "@/config/paths";
@@ -28,7 +28,7 @@ import { useLogin } from "@/features/auth";
 import { getUserInfo } from "@/hooks";
 import { publicApiClient } from "@/lib";
 import { useErrorMessageStore, useUserAuthStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useLogin", () => {
     const wrapper = createQueryWrapper();
@@ -69,9 +69,7 @@ describe("useLogin", () => {
         const { result } = renderHook(() => useLogin(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -98,9 +96,7 @@ describe("useLogin", () => {
         const { result } = renderHook(() => useLogin(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/auth/hooks/__tests__/useRequestPasswordReset.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useRequestPasswordReset.test.ts
@@ -5,14 +5,14 @@ vi.mock("@/lib", () => ({
     publicApiClient: { post: vi.fn() },
 }));
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import type { RequestPasswordResetPayload } from "@/features/auth";
 import { useRequestPasswordReset } from "@/features/auth";
 import { publicApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useRequestPasswordReset", () => {
     const wrapper = createQueryWrapper();
@@ -37,9 +37,7 @@ describe("useRequestPasswordReset", () => {
         const { result } = renderHook(() => useRequestPasswordReset(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/auth/hooks/__tests__/useResetPassword.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useResetPassword.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 import type * as ReactRouter from "react-router";
 import { vi } from "vitest";
@@ -22,7 +22,7 @@ import type { ResetPasswordPayload } from "@/features/auth";
 import { useResetPassword } from "@/features/auth";
 import { publicApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useResetPassword", () => {
     const wrapper = createQueryWrapper();
@@ -53,9 +53,7 @@ describe("useResetPassword", () => {
         const { result } = renderHook(() => useResetPassword(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/auth/hooks/__tests__/useUserRegister.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useUserRegister.test.ts
@@ -15,7 +15,7 @@ vi.mock("react-router", async () => {
     };
 });
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { paths } from "@/config/paths";
@@ -23,7 +23,7 @@ import type { UserRegistrationPayload } from "@/features/auth";
 import { useUserRegister } from "@/features/auth";
 import { publicApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useUserRegister", () => {
     const wrapper = createQueryWrapper();
@@ -55,9 +55,7 @@ describe("useUserRegister", () => {
         const { result } = renderHook(() => useUserRegister(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/auth/hooks/__tests__/useVerifyTwoFactor.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useVerifyTwoFactor.test.ts
@@ -16,14 +16,14 @@ vi.mock("react-router", async () => {
     };
 });
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { paths } from "@/config/paths";
 import { useVerifyTwoFactor } from "@/features/auth";
 import { protectedApiClient, publicApiClient } from "@/lib";
 import { useErrorMessageStore, useUserAuthStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useVerifyTwoFactor", () => {
     const wrapper = createQueryWrapper();
@@ -61,9 +61,7 @@ describe("useVerifyTwoFactor", () => {
         const { result } = renderHook(() => useVerifyTwoFactor(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(dummyCode);
-        });
+        mutateHook(result, dummyCode);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/user/hooks/__tests__/useChangePassword.test.ts
+++ b/frontend/src/features/user/hooks/__tests__/useChangePassword.test.ts
@@ -5,14 +5,14 @@ vi.mock("@/lib", () => ({
     protectedApiClient: { patch: vi.fn() },
 }));
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import type { ChangePasswordPayload } from "@/features/user";
 import { useChangePassword } from "@/features/user";
 import { protectedApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useChangePassword", () => {
     const wrapper = createQueryWrapper();
@@ -40,9 +40,7 @@ describe("useChangePassword", () => {
         const { result } = renderHook(() => useChangePassword(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/user/hooks/__tests__/useDeleteUser.test.ts
+++ b/frontend/src/features/user/hooks/__tests__/useDeleteUser.test.ts
@@ -15,14 +15,14 @@ vi.mock("react-router", async () => {
     };
 });
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { paths } from "@/config/paths";
 import { useDeleteUser } from "@/features/user";
 import { protectedApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore, useUserAuthStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useDeleteUser", () => {
     const wrapper = createQueryWrapper();
@@ -47,9 +47,7 @@ describe("useDeleteUser", () => {
         const { result } = renderHook(() => useDeleteUser(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate();
-        });
+        mutateHook(result, undefined);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/user/hooks/__tests__/useRemoveAuthProvider.test.ts
+++ b/frontend/src/features/user/hooks/__tests__/useRemoveAuthProvider.test.ts
@@ -5,13 +5,13 @@ vi.mock("@/lib", () => ({
     protectedApiClient: { delete: vi.fn() },
 }));
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { useRemoveAuthProvider } from "@/features/user";
 import { protectedApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore, useUserAuthStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 import type { AuthProvider, User } from "@/types";
 
 describe("useRemoveAuthProvider", () => {
@@ -50,9 +50,7 @@ describe("useRemoveAuthProvider", () => {
         const { result } = renderHook(() => useRemoveAuthProvider(), { wrapper });
 
         // ミューテート実行（"google"を解除）
-        act(() => {
-            result.current.mutate("google" as AuthProvider);
-        });
+        mutateHook(result, "google" as AuthProvider);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/user/hooks/__tests__/useSetEmailAndPassword.test.ts
+++ b/frontend/src/features/user/hooks/__tests__/useSetEmailAndPassword.test.ts
@@ -15,7 +15,7 @@ vi.mock("react-router", async () => {
     };
 });
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { paths } from "@/config/paths";
@@ -23,7 +23,7 @@ import type { SetEmailAndPasswordPayload } from "@/features/user";
 import { useSetEmailAndPassword } from "@/features/user";
 import { protectedApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore, useUserAuthStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 import type { User } from "@/types";
 
 describe("useSetEmailAndPassword", () => {
@@ -64,9 +64,7 @@ describe("useSetEmailAndPassword", () => {
         const { result } = renderHook(() => useSetEmailAndPassword(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -109,9 +107,7 @@ describe("useSetEmailAndPassword", () => {
         const { result } = renderHook(() => useSetEmailAndPassword(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/features/user/hooks/__tests__/useUpdateUserInfo.test.ts
+++ b/frontend/src/features/user/hooks/__tests__/useUpdateUserInfo.test.ts
@@ -5,14 +5,14 @@ vi.mock("@/lib", () => ({
     protectedApiClient: { put: vi.fn() },
 }));
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import type { UpdateUserInfoPayload } from "@/features/user";
 import { useUpdateUserInfo } from "@/features/user";
 import { protectedApiClient } from "@/lib";
 import { useErrorMessageStore, useNotificationStore, useUserAuthStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 import type { User } from "@/types";
 
 describe("useUpdateUserInfo", () => {
@@ -50,9 +50,7 @@ describe("useUpdateUserInfo", () => {
         const { result } = renderHook(() => useUpdateUserInfo(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate(payload);
-        });
+        mutateHook(result, payload);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/hooks/__tests__/useLogout.test.ts
+++ b/frontend/src/hooks/__tests__/useLogout.test.ts
@@ -10,14 +10,14 @@ vi.mock("react-router", () => ({
     useNavigate: () => mockedNavigate,
 }));
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AxiosResponse } from "axios";
 
 import { paths } from "@/config/paths";
 import { useLogout } from "@/hooks";
 import { protectedApiClient } from "@/lib";
 import { useUserAuthStore } from "@/stores";
-import { createQueryWrapper, resetStoresAndMocks } from "@/test";
+import { createQueryWrapper, mutateHook, resetStoresAndMocks } from "@/test";
 
 describe("useLogout", () => {
     const wrapper = createQueryWrapper();
@@ -40,9 +40,7 @@ describe("useLogout", () => {
         const { result } = renderHook(() => useLogout(), { wrapper });
 
         // ミューテート実行
-        act(() => {
-            result.current.mutate();
-        });
+        mutateHook(result, undefined);
 
         // 成功状態になるまで待機
         await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/test/testUtils.tsx
+++ b/frontend/src/test/testUtils.tsx
@@ -1,10 +1,21 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { vi } from "vitest";
 
 import { useErrorMessageStore, useNotificationStore } from "@/stores";
 
 type MockItem = (() => void) | { mockReset: () => void };
+
+type MutationHookResult<TPayload> = {
+    current: {
+        mutate: (payload: TPayload) => void;
+    };
+};
+
+type AsyncHookResult<TStatus extends "isSuccess" | "isError"> = {
+    current: Record<TStatus, boolean>;
+};
 
 /**
  * React Queryのテスト用ラッパーを生成する
@@ -31,6 +42,20 @@ export const createQueryWrapper = () => {
 
     return Wrapper;
 };
+
+export function mutateHook<TPayload>(result: MutationHookResult<TPayload>, payload: TPayload) {
+    act(() => {
+        result.current.mutate(payload);
+    });
+}
+
+export async function waitForHookSuccess(result: AsyncHookResult<"isSuccess">) {
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+}
+
+export async function waitForHookError(result: AsyncHookResult<"isError">) {
+    await waitFor(() => expect(result.current.isError).toBe(true));
+}
 
 /**
  * beforeEachで呼び出し、テスト前にストアをクリアし、引数に渡したモック関数（または spyOn の戻り値）をリセットする

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,11 +10,6 @@ interface ExtendedUserConfig extends UserConfig {
         setupFiles: string[];
         reporters: (string | [string, { outputFile: string }])[];
         pool: string;
-        poolOptions: {
-            forks: {
-                singleFork: boolean;
-            };
-        };
         deps: {
             interopDefault: boolean;
         };
@@ -42,11 +37,6 @@ export default defineConfig({
         setupFiles: ["./vitest-setup.ts"],
         reporters: ["default", ["junit", { outputFile: "test-results/junit.xml" }]],
         pool: "forks",
-        poolOptions: {
-            forks: {
-                singleFork: true,
-            },
-        },
         deps: {
             interopDefault: true,
         },


### PR DESCRIPTION
Changes:
Vitest 4で非推奨となった`test.poolOptions`設定を削除。
hook mutationテストの`act`内で`mutate`を呼ぶ共通処理を`mutateHook`に集約。 既存hookテストの検証内容を維持したまま、重複していたmutation実行部分を更新。

Reason:
Vitest実行時に出ていた`test.poolOptions`の非推奨警告を解消し、hookテストの意図を保ちながらテストコードの重複を減らすため。

BREAKING CHANGE: N/A
Related: N/A
Refs: N/A