### PR TITLE
fix: frontend deployのAxiosレスポンスモック型エラーを修正

### DIFF
--- a/frontend/src/features/resume/components/__tests__/resumeBackup.integration.test.tsx
+++ b/frontend/src/features/resume/components/__tests__/resumeBackup.integration.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from "@testing-library/react";
-import type { AxiosResponse } from "axios";
 import { vi } from "vitest";
 
 vi.mock("@/lib", () => ({
@@ -12,10 +11,9 @@ vi.mock("file-saver", () => ({
     saveAs: vi.fn(),
 }));
 
-import type { GetResumeListResponse } from "@/features/resume";
 import { BackupContainer, BackupSection } from "@/features/resume";
 import { protectedApiClient } from "@/lib";
-import { renderWithProviders, resetStoresAndMocks } from "@/test";
+import { createAxiosResponse, renderWithProviders, resetStoresAndMocks } from "@/test";
 
 import { resumeSummaries } from "./resumeTestData";
 
@@ -23,10 +21,11 @@ describe("resume backup", () => {
     beforeEach(() => {
         resetStoresAndMocks([]);
         vi.mocked(protectedApiClient.get).mockReset();
-        vi.mocked(protectedApiClient.get).mockResolvedValue({
-            data: new Blob(["{}"], { type: "application/json" }),
-            headers: { "content-disposition": 'attachment; filename="backup.json"' },
-        } as unknown as AxiosResponse<Blob>);
+        vi.mocked(protectedApiClient.get).mockResolvedValue(
+            createAxiosResponse(new Blob(["{}"], { type: "application/json" }), {
+                headers: { "content-disposition": 'attachment; filename="backup.json"' },
+            }),
+        );
     });
 
     it("BackupSectionは未選択では実行できずconfirm時だけバックアップAPIを呼ぶこと", async () => {
@@ -64,9 +63,7 @@ describe("resume backup", () => {
     });
 
     it("BackupContainerは一覧取得後に対象がない場合だけ空表示を出すこと", async () => {
-        vi.mocked(protectedApiClient.get).mockResolvedValueOnce({
-            data: { resumes: [] },
-        } as AxiosResponse<GetResumeListResponse>);
+        vi.mocked(protectedApiClient.get).mockResolvedValueOnce(createAxiosResponse({ resumes: [] }));
 
         renderWithProviders(<BackupContainer />);
 

--- a/frontend/src/features/resume/components/__tests__/resumeEditor.integration.test.tsx
+++ b/frontend/src/features/resume/components/__tests__/resumeEditor.integration.test.tsx
@@ -40,7 +40,7 @@ import { lightTheme } from "@/config/theme";
 import type { Resume } from "@/features/resume";
 import { ResumeContainer, useGetResumeList, useResumeStore } from "@/features/resume";
 import { protectedApiClient } from "@/lib";
-import { createTestQueryClient, resetStoresAndMocks } from "@/test";
+import { createAxiosResponse, createTestQueryClient, resetStoresAndMocks } from "@/test";
 
 import { cloneResume, emptyTechStack, resumeSummaries } from "./resumeTestData";
 
@@ -117,38 +117,40 @@ describe("resume editor", () => {
 
         vi.mocked(protectedApiClient.get).mockImplementation((url: string) => {
             if (url === "/resumes/resume-1") {
-                return Promise.resolve({ data: cloneResume() } as AxiosResponse<Resume>);
+                return Promise.resolve(createAxiosResponse(cloneResume()));
             }
             if (url === "/resumes") {
-                return Promise.resolve({ data: { resumes: resumeSummaries } });
+                return Promise.resolve(createAxiosResponse({ resumes: resumeSummaries }));
             }
             if (url === "/tech-stacks") {
-                return Promise.resolve({ data: emptyTechStack } as AxiosResponse<typeof emptyTechStack>);
+                return Promise.resolve(createAxiosResponse(emptyTechStack));
             }
             if (url === "/resumes/resume-1/export") {
-                return Promise.resolve({
-                    data: new Blob(["exported"]),
-                    headers: {},
-                } as AxiosResponse<Blob>);
+                return Promise.resolve(
+                    createAxiosResponse(new Blob(["exported"]), {
+                        headers: {},
+                    }),
+                );
             }
-            return Promise.resolve({ data: undefined } as AxiosResponse<void>);
+            return Promise.resolve(createAxiosResponse(undefined));
         });
         vi.mocked(protectedApiClient.post).mockImplementation((url: string) => {
             if (url === "/resumes/resume-1/export") {
-                return Promise.resolve({
-                    data: new Blob(["pdf"], { type: "application/pdf" }),
-                    headers: { "content-disposition": 'attachment; filename="resume.pdf"' },
-                } as unknown as AxiosResponse<Blob>);
+                return Promise.resolve(
+                    createAxiosResponse(new Blob(["pdf"], { type: "application/pdf" }), {
+                        headers: { "content-disposition": 'attachment; filename="resume.pdf"' },
+                    }),
+                );
             }
-            return Promise.resolve({ data: cloneResume() } as AxiosResponse<Resume>);
+            return Promise.resolve(createAxiosResponse(cloneResume()));
         });
         vi.mocked(protectedApiClient.put).mockImplementation((url: string, payload: unknown) => {
             if (url === "/resumes/resume-1/basic") {
-                return Promise.resolve({ data: cloneResume(payload as Partial<Resume>) } as AxiosResponse<Resume>);
+                return Promise.resolve(createAxiosResponse(cloneResume(payload as Partial<Resume>)));
             }
-            return Promise.resolve({ data: cloneResume() } as AxiosResponse<Resume>);
+            return Promise.resolve(createAxiosResponse(cloneResume()));
         });
-        vi.mocked(protectedApiClient.delete).mockResolvedValue({ data: undefined } as AxiosResponse<void>);
+        vi.mocked(protectedApiClient.delete).mockResolvedValue(createAxiosResponse(undefined));
     });
 
     it("section tab切り替えで表示セクションとstoreを更新すること", async () => {
@@ -316,10 +318,11 @@ describe("resume editor", () => {
         expect(screen.queryByRole("dialog", { name: "PDFプレビュー" })).not.toBeInTheDocument();
 
         act(() => {
-            resolvePreviewRequest({
-                data: new Blob(["pdf"], { type: "application/pdf" }),
-                headers: {},
-            } as AxiosResponse<Blob>);
+            resolvePreviewRequest(
+                createAxiosResponse(new Blob(["pdf"], { type: "application/pdf" }), {
+                    headers: {},
+                }),
+            );
         });
 
         expect(await screen.findByRole("dialog", { name: "PDFプレビュー" })).toBeInTheDocument();

--- a/frontend/src/features/resume/components/__tests__/resumeList.integration.test.tsx
+++ b/frontend/src/features/resume/components/__tests__/resumeList.integration.test.tsx
@@ -10,11 +10,11 @@ vi.mock("@/lib", () => ({
     },
 }));
 
-import type { GetResumeListResponse, Resume } from "@/features/resume";
+import type { GetResumeListResponse } from "@/features/resume";
 import { CreateResumeContainer, ResumeListContainer } from "@/features/resume";
 import { protectedApiClient } from "@/lib";
 import { useNotificationStore } from "@/stores";
-import { renderWithProviders, resetStoresAndMocks } from "@/test";
+import { createAxiosResponse, renderWithProviders, resetStoresAndMocks } from "@/test";
 
 import { cloneResume, resumeSummaries } from "./resumeTestData";
 
@@ -25,19 +25,16 @@ describe("resume list", () => {
         URL.revokeObjectURL = vi.fn();
         vi.mocked(protectedApiClient.get).mockReset();
         vi.mocked(protectedApiClient.post).mockReset();
-        vi.mocked(protectedApiClient.get).mockResolvedValue({
-            data: { resumes: resumeSummaries },
-        } as AxiosResponse<GetResumeListResponse>);
+        vi.mocked(protectedApiClient.get).mockResolvedValue(createAxiosResponse({ resumes: resumeSummaries }));
         vi.mocked(protectedApiClient.post).mockImplementation((url: string) => {
             if (url === "/resumes/resume-1/export") {
-                return Promise.resolve({
-                    data: new Blob(["pdf"], { type: "application/pdf" }),
-                    headers: {},
-                } as AxiosResponse<Blob>);
+                return Promise.resolve(
+                    createAxiosResponse(new Blob(["pdf"], { type: "application/pdf" }), {
+                        headers: {},
+                    }),
+                );
             }
-            return Promise.resolve({
-                data: cloneResume({ id: "created-resume" }),
-            } as AxiosResponse<Resume>);
+            return Promise.resolve(createAxiosResponse(cloneResume({ id: "created-resume" })));
         });
     });
 
@@ -60,9 +57,7 @@ describe("resume list", () => {
     });
 
     it("ResumeListContainerはempty時にNoData表示に切り替わること", async () => {
-        vi.mocked(protectedApiClient.get).mockResolvedValueOnce({
-            data: { resumes: [] },
-        } as unknown as AxiosResponse<GetResumeListResponse>);
+        vi.mocked(protectedApiClient.get).mockResolvedValueOnce(createAxiosResponse({ resumes: [] }));
 
         renderWithProviders(<ResumeListContainer />);
 
@@ -83,7 +78,7 @@ describe("resume list", () => {
         expect(screen.queryByText("表示するデータがありません。")).not.toBeInTheDocument();
 
         act(() => {
-            resolveListRequest({ data: { resumes: [] } } as AxiosResponse<GetResumeListResponse>);
+            resolveListRequest(createAxiosResponse({ resumes: [] }));
         });
 
         expect(await screen.findByText("表示するデータがありません。")).toBeInTheDocument();
@@ -176,9 +171,9 @@ describe("resume list", () => {
         vi.mocked(protectedApiClient.get).mockImplementation((url: string) => {
             if (url === "/resumes") {
                 listRequestCount += 1;
-                return Promise.resolve({
-                    data: { resumes: listRequestCount === 1 ? resumeSummaries : [resumeSummaries[1]] },
-                } as AxiosResponse<GetResumeListResponse>);
+                return Promise.resolve(
+                    createAxiosResponse({ resumes: listRequestCount === 1 ? resumeSummaries : [resumeSummaries[1]] }),
+                );
             }
             if (url === "/resumes/resume-1/export") {
                 return Promise.reject({
@@ -189,7 +184,7 @@ describe("resume list", () => {
                     },
                 });
             }
-            return Promise.resolve({ data: undefined } as AxiosResponse<void>);
+            return Promise.resolve(createAxiosResponse(undefined));
         });
 
         const { user } = renderWithProviders(<ResumeListContainer />, { route: "/resume/list" });
@@ -210,11 +205,11 @@ describe("resume list", () => {
         vi.mocked(protectedApiClient.get).mockImplementation((url: string) => {
             if (url === "/resumes") {
                 listRequestCount += 1;
-                return Promise.resolve({
-                    data: { resumes: listRequestCount === 1 ? resumeSummaries : [resumeSummaries[1]] },
-                } as AxiosResponse<GetResumeListResponse>);
+                return Promise.resolve(
+                    createAxiosResponse({ resumes: listRequestCount === 1 ? resumeSummaries : [resumeSummaries[1]] }),
+                );
             }
-            return Promise.resolve({ data: undefined } as AxiosResponse<void>);
+            return Promise.resolve(createAxiosResponse(undefined));
         });
         vi.mocked(protectedApiClient.post).mockImplementationOnce(
             () =>

--- a/frontend/src/test/testUtils.tsx
+++ b/frontend/src/test/testUtils.tsx
@@ -4,6 +4,8 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { AxiosResponse } from "axios";
+import { AxiosHeaders } from "axios";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { vi } from "vitest";
@@ -25,6 +27,20 @@ type MutationHookResult<TPayload> = {
 type AsyncHookResult<TStatus extends "isSuccess" | "isError"> = {
     current: Record<TStatus, boolean>;
 };
+
+export const createAxiosResponse = <T,>(
+    data: T,
+    overrides: Partial<Omit<AxiosResponse<T>, "data">> = {},
+): AxiosResponse<T> => ({
+    data,
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config: {
+        headers: new AxiosHeaders(),
+    },
+    ...overrides,
+});
 
 /**
  * React Queryのテスト用ラッパーを生成する


### PR DESCRIPTION
Changes:
- AxiosResponseの必須フィールドを持つテスト用レスポンス生成ヘルパーを追加
- resume統合テストの不完全なAPIレスポンスモックを型安全な生成方法へ置換
- frontend buildで発生していたTS2352を解消

Reason:
- frontend-deployのBuildステップを停止させていた型不整合を、型アサーション回避ではなく正しいモック構造で修正するため

BREAKING CHANGE: N/A
Related: N/A
Refs: N/A