### PR TITLE
fix: ポートフォリオ技術スタックを任意項目として整合化

### DIFF
--- a/backend/src/main/resources/db/migration/V5__allow_nullable_portfolio_tech_stack.sql
+++ b/backend/src/main/resources/db/migration/V5__allow_nullable_portfolio_tech_stack.sql
@@ -1,0 +1,3 @@
+-- ポートフォリオの技術スタックは任意項目のためNULLを許容する
+ALTER TABLE portfolios
+    ALTER COLUMN tech_stack DROP NOT NULL;

--- a/backend/src/test/java/com/example/keirekipro/unit/infrastructure/repository/resume/ResumeMapperTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/infrastructure/repository/resume/ResumeMapperTest.java
@@ -35,7 +35,7 @@ import lombok.RequiredArgsConstructor;
 
 @MybatisTest
 @ActiveProfiles("test")
-@TestPropertySource(properties = "spring.flyway.target=1")
+@TestPropertySource(properties = "spring.flyway.target=5")
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -998,6 +998,36 @@ class ResumeMapperTest {
     }
 
     @Test
+    @DisplayName("insertPortfolio_技術スタックがNULLのポートフォリオを挿入して取得できる")
+    void test24_1() {
+        userMapper.upsertUser(createUserDto());
+        ResumeDto resume = createResumeDto(
+                RESUME_ID_1,
+                USER_ID,
+                NAME_1,
+                DATE_1,
+                LAST_NAME_1,
+                FIRST_NAME_1,
+                CREATED,
+                UPDATED);
+        resumeMapper.upsert(resume);
+
+        UUID portId = UUID.fromString("87878787-8787-8787-8787-878787878787");
+        PortfolioDto port = createPortfolioDto(
+                portId,
+                RESUME_ID_1,
+                "PortName",
+                "PortOverview",
+                null,
+                "http://link");
+        resumeMapper.insertPortfolio(port);
+
+        List<PortfolioDto> list = resumeMapper.selectPortfoliosByResumeId(RESUME_ID_1);
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0).getTechStack()).isNull();
+    }
+
+    @Test
     @DisplayName("updatePortfolio_既存のポートフォリオを更新すると、各フィールドが反映される")
     void test25() {
         userMapper.upsertUser(createUserDto());
@@ -1038,6 +1068,45 @@ class ResumeMapperTest {
         assertThat(loaded.getOverview()).isEqualTo("NewOv");
         assertThat(loaded.getTechStack()).isEqualTo("NewTech");
         assertThat(loaded.getLink()).isEqualTo("http://new");
+    }
+
+    @Test
+    @DisplayName("updatePortfolio_技術スタックをNULLに更新して取得できる")
+    void test25_1() {
+        userMapper.upsertUser(createUserDto());
+        ResumeDto resume = createResumeDto(
+                RESUME_ID_1,
+                USER_ID,
+                NAME_1,
+                DATE_1,
+                LAST_NAME_1,
+                FIRST_NAME_1,
+                CREATED,
+                UPDATED);
+        resumeMapper.upsert(resume);
+
+        UUID portId = UUID.fromString("89898989-8989-8989-8989-898989898989");
+        PortfolioDto original = createPortfolioDto(
+                portId,
+                RESUME_ID_1,
+                "OldName",
+                "OldOv",
+                "OldTech",
+                "http://old");
+        resumeMapper.insertPortfolio(original);
+
+        PortfolioDto updated = createPortfolioDto(
+                portId,
+                RESUME_ID_1,
+                "NewName",
+                "NewOv",
+                null,
+                "http://new");
+        resumeMapper.updatePortfolio(updated);
+
+        List<PortfolioDto> list = resumeMapper.selectPortfoliosByResumeId(RESUME_ID_1);
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0).getTechStack()).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/resume/CreatePortfolioUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/resume/CreatePortfolioUseCaseTest.java
@@ -93,6 +93,25 @@ class CreatePortfolioUseCaseTest {
     }
 
     @Test
+    @DisplayName("技術スタックが未入力でもポートフォリオを新規作成できる")
+    void test1_1() {
+        CreatePortfolioRequest request = new CreatePortfolioRequest();
+        request.setName("作品1");
+        request.setOverview("概要1");
+        request.setTechStack(null);
+        request.setLink("https://example.com");
+
+        doNothing().when(checker).checkPortfolioAddAllowed(RESUME_ID);
+        when(repository.find(RESUME_ID)).thenReturn(Optional.of(buildResume(USER_ID)));
+
+        useCase.execute(USER_ID, RESUME_ID.toString(), request);
+
+        ArgumentCaptor<Resume> saveCaptor = ArgumentCaptor.forClass(Resume.class);
+        verify(repository).save(saveCaptor.capture());
+        assertThat(saveCaptor.getValue().getPortfolios().get(0).getTechStack()).isNull();
+    }
+
+    @Test
     @DisplayName("対象の職務経歴書が存在しない場合、UseCaseExceptionがスローされる")
     void test2() {
         CreatePortfolioRequest request = new CreatePortfolioRequest();

--- a/backend/src/test/java/com/example/keirekipro/unit/usecase/resume/UpdatePortfolioUseCaseTest.java
+++ b/backend/src/test/java/com/example/keirekipro/unit/usecase/resume/UpdatePortfolioUseCaseTest.java
@@ -115,6 +115,33 @@ class UpdatePortfolioUseCaseTest {
     }
 
     @Test
+    @DisplayName("技術スタックが未入力でもポートフォリオを更新できる")
+    void test1_1() {
+        Resume resume = buildResumeWithPortfolios(USER_ID);
+        UUID portfolioId = resume.getPortfolios().stream()
+                .filter(p -> "ポートフォリオ1".equals(p.getName()))
+                .map(Portfolio::getId)
+                .findFirst()
+                .orElseThrow();
+        UpdatePortfolioRequest request = new UpdatePortfolioRequest(
+                "更新後ポートフォリオ",
+                "更新後概要",
+                null,
+                "https://example.com/updated");
+        when(repository.find(RESUME_ID)).thenReturn(Optional.of(resume));
+
+        useCase.execute(USER_ID, RESUME_ID.toString(), portfolioId, request);
+
+        ArgumentCaptor<Resume> saveCaptor = ArgumentCaptor.forClass(Resume.class);
+        verify(repository).save(saveCaptor.capture());
+        Portfolio updated = saveCaptor.getValue().getPortfolios().stream()
+                .filter(p -> p.getId().equals(portfolioId))
+                .findFirst()
+                .orElseThrow();
+        assertThat(updated.getTechStack()).isNull();
+    }
+
+    @Test
     @DisplayName("対象の職務経歴書が存在しない場合、UseCaseExceptionがスローされる")
     void test2() {
         // リクエスト準備

--- a/doc/DB設計/ER図.pu
+++ b/doc/DB設計/ER図.pu
@@ -137,7 +137,7 @@ entity "ポートフォリオ(portfolios)" as Portfolios {
     resume_id : <color:#1E90FF>UUID</color> <color:#32CD32>[NOT NULL]</color> -- 職務経歴書ID
     name : <color:#1E90FF>VARCHAR(255)</color> <color:#32CD32>[NOT NULL]</color> -- ポートフォリオ名
     overview : <color:#1E90FF>VARCHAR(255)</color> <color:#32CD32>[NOT NULL]</color> -- 概要
-    tech_stack : <color:#1E90FF>TEXT</color> <color:#32CD32>[NOT NULL]</color> -- 技術スタック
+    tech_stack : <color:#1E90FF>TEXT</color> -- 技術スタック
     link : <color:#1E90FF>VARCHAR(255)</color> <color:#32CD32>[NOT NULL]</color> -- リンク
 }
 

--- a/frontend/src/features/resume/api/portfolio/createPortfolio.ts
+++ b/frontend/src/features/resume/api/portfolio/createPortfolio.ts
@@ -8,7 +8,7 @@ import type { AxiosResponse } from "axios";
 export interface CreatePortfolioPayload {
     name: string;
     overview: string;
-    techStack?: string;
+    techStack: string | null;
     link: string;
 }
 

--- a/frontend/src/features/resume/api/portfolio/updatePortfolio.ts
+++ b/frontend/src/features/resume/api/portfolio/updatePortfolio.ts
@@ -8,7 +8,7 @@ import type { AxiosResponse } from "axios";
 export interface UpdatePortfolioPayload {
     name: string;
     overview: string;
-    techStack?: string;
+    techStack: string | null;
     link: string;
 }
 

--- a/frontend/src/features/resume/components/resume/section/PortfolioSection.tsx
+++ b/frontend/src/features/resume/components/resume/section/PortfolioSection.tsx
@@ -88,11 +88,10 @@ export const PortfolioSection = () => {
             <TextField
                 label="技術スタック"
                 fullWidth
-                required
                 multiline
                 minRows={4}
                 placeholder="（例）React, TypeScript, Firebase"
-                value={currentPortfolio.techStack}
+                value={currentPortfolio.techStack ?? ""}
                 onChange={(e) => updateEntry("portfolios", currentPortfolio.id, { techStack: e.target.value })}
                 error={!!errors.techStack?.length}
                 helperText={stringListToBulletList(errors.techStack)}

--- a/frontend/src/features/resume/types/index.ts
+++ b/frontend/src/features/resume/types/index.ts
@@ -97,7 +97,7 @@ export interface Portfolio {
     id: string;
     name: string;
     overview: string;
-    techStack: string;
+    techStack: string | null;
     link: string;
 }
 

--- a/frontend/src/features/resume/utils/__tests__/index.test.ts
+++ b/frontend/src/features/resume/utils/__tests__/index.test.ts
@@ -439,6 +439,25 @@ describe("buildPayloadForEntry", () => {
         expect(result).not.toHaveProperty("id");
     });
 
+    it("portfolioの技術スタックが空文字の場合、nullを含むAPI送信用ペイロードを返すこと", () => {
+        const entry = {
+            id: "portfolio-1",
+            name: "個人ブログ",
+            overview: "技術ブログ",
+            techStack: "",
+            link: "https://example.com/blog",
+        };
+
+        const result = buildPayloadForEntry("portfolio", entry);
+
+        expect(result).toEqual({
+            name: "個人ブログ",
+            overview: "技術ブログ",
+            techStack: null,
+            link: "https://example.com/blog",
+        });
+    });
+
     it("snsPlatformの場合、API送信用のペイロードを返すこと", () => {
         const entry = {
             id: "snsPlatform-1",

--- a/frontend/src/features/resume/utils/index.ts
+++ b/frontend/src/features/resume/utils/index.ts
@@ -187,7 +187,7 @@ export const buildPayloadForEntry = (sectionOrType: SectionName | string, entry:
             return {
                 name: entry.name,
                 overview: entry.overview,
-                techStack: entry.techStack,
+                techStack: entry.techStack === "" ? null : entry.techStack,
                 link: entry.link,
             };
         case "snsPlatform":


### PR DESCRIPTION
Changes:
ポートフォリオの技術スタックの必須表示を削除し、空欄時はnullを送信するよう変更
tech_stackのNOT NULL制約を解除するmigrationとER図更新、NULL永続化テストを追加

Reason:
ドメインルール上は任意項目である技術スタックについて、フロント表示とDB制約の不整合を解消するため

BREAKING CHANGE: N/A
Related: https://github.com/DogisRiki/KeirekiPro/issues/29
Refs: #29