### PR TITLE
fix: ローディング表示範囲を画面領域ごとに調整

### DIFF
--- a/frontend/src/components/__tests__/uiControls.integration.test.tsx
+++ b/frontend/src/components/__tests__/uiControls.integration.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import { useState } from "react";
@@ -7,7 +7,6 @@ import { vi } from "vitest";
 import { DatePicker, Dialog, Loading, PasswordTextField, ScrollToTopButton, ThemeSwitch } from "@/components/ui";
 import { useThemeStore } from "@/stores";
 import { renderWithProviders, resetStoresAndMocks } from "@/test";
-import { useMutation, useQuery } from "@tanstack/react-query";
 
 describe("ui controls", () => {
     beforeEach(() => {
@@ -103,44 +102,26 @@ describe("ui controls", () => {
         expect(selectedValue?.format("YYYY-MM-DD")).toBe("2024-01-15");
     });
 
-    it("LoadingはReact Queryのfetch/mutation中だけ表示されること", async () => {
-        let resolveQuery: (value: string) => void = () => {};
-        let resolveMutation: () => void = () => {};
+    it("Loadingはactiveに応じて表示を切り替えること", () => {
+        const { rerender } = renderWithProviders(<Loading active />);
 
-        const QueryAndMutation = () => {
-            const mutation = useMutation({
-                mutationFn: () =>
-                    new Promise<void>((resolve) => {
-                        resolveMutation = resolve;
-                    }),
-            });
-            useQuery({
-                queryKey: ["loading-test"],
-                queryFn: () =>
-                    new Promise<string>((resolve) => {
-                        resolveQuery = resolve;
-                    }),
-            });
-            return <button onClick={() => mutation.mutate()}>mutate</button>;
-        };
+        expect(screen.getByRole("progressbar")).toBeVisible();
 
-        const { user } = renderWithProviders(
-            <>
-                <Loading />
-                <QueryAndMutation />
-            </>,
+        rerender(<Loading active={false} />);
+
+        expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+
+    it("Loadingのoverlayは対象領域内に表示すること", () => {
+        renderWithProviders(
+            <div style={{ position: "relative", minHeight: 120 }}>
+                <button>対象操作</button>
+                <Loading active variant="overlay" />
+            </div>,
         );
 
-        const queryProgress = await screen.findByRole("progressbar", { hidden: true });
-        expect(queryProgress).toBeVisible();
-        act(() => resolveQuery("done"));
-        await waitFor(() => expect(queryProgress).not.toBeVisible());
-
-        await user.click(screen.getByRole("button", { name: "mutate" }));
-        const mutationProgress = await screen.findByRole("progressbar", { hidden: true });
-        expect(mutationProgress).toBeVisible();
-        act(() => resolveMutation());
-        await waitFor(() => expect(mutationProgress).not.toBeVisible());
+        expect(screen.getByRole("button", { name: "対象操作" })).toBeInTheDocument();
+        expect(screen.getByRole("progressbar")).toBeVisible();
     });
 
     it("ScrollToTopButtonはスクロール後に表示されクリックで先頭へ戻すこと", async () => {

--- a/frontend/src/components/ui/Loading.tsx
+++ b/frontend/src/components/ui/Loading.tsx
@@ -1,23 +1,71 @@
-import { Backdrop, CircularProgress } from "@mui/material";
-import { useIsFetching, useIsMutating } from "@tanstack/react-query";
+import { Box, CircularProgress } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+import { alpha } from "@mui/material/styles";
+
+type LoadingVariant = "content" | "inline" | "overlay";
+
+interface LoadingProps {
+    active: boolean;
+    variant?: LoadingVariant;
+    size?: number;
+    sx?: SxProps<Theme>;
+}
+
+const mergeSx = (baseSx: SxProps<Theme>, sx?: SxProps<Theme>): SxProps<Theme> => {
+    if (!sx) return baseSx;
+    return {
+        ...(baseSx as object),
+        ...(sx as object),
+    };
+};
 
 /**
  * ローディング
  */
-export const Loading = () => {
-    const fetching = useIsFetching();
-    const mutating = useIsMutating();
-    const open = fetching + mutating > 0;
+export const Loading = ({ active, variant = "content", size = 40, sx }: LoadingProps) => {
+    if (!active) return null;
+
+    if (variant === "inline") {
+        return <CircularProgress size={size} sx={sx} />;
+    }
+
+    const progress = <CircularProgress size={size} />;
+
+    if (variant === "overlay") {
+        return (
+            <Box
+                sx={mergeSx(
+                    {
+                        position: "absolute",
+                        inset: 0,
+                        zIndex: 1,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        bgcolor: (theme) => alpha(theme.palette.background.paper, 0.72),
+                    },
+                    sx,
+                )}
+            >
+                {progress}
+            </Box>
+        );
+    }
 
     return (
-        <Backdrop
-            open={open}
-            sx={{
-                zIndex: (t) => t.zIndex.modal + 1,
-                bgcolor: "rgba(0,0,0,0.4)",
-            }}
+        <Box
+            sx={mergeSx(
+                {
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: "100%",
+                    minHeight: 240,
+                },
+                sx,
+            )}
         >
-            <CircularProgress size={60} color="inherit" />
-        </Backdrop>
+            {progress}
+        </Box>
     );
 };

--- a/frontend/src/features/resume/components/__tests__/resumeBackup.integration.test.tsx
+++ b/frontend/src/features/resume/components/__tests__/resumeBackup.integration.test.tsx
@@ -59,6 +59,7 @@ describe("resume backup", () => {
 
         renderWithProviders(<BackupContainer />);
 
+        expect(screen.getByRole("progressbar")).toBeVisible();
         expect(screen.queryByText("バックアップ可能な職務経歴書がありません。")).not.toBeInTheDocument();
     });
 

--- a/frontend/src/features/resume/components/__tests__/resumeEditor.integration.test.tsx
+++ b/frontend/src/features/resume/components/__tests__/resumeEditor.integration.test.tsx
@@ -154,6 +154,20 @@ describe("resume editor", () => {
         vi.mocked(protectedApiClient.delete).mockResolvedValue(createAxiosResponse(undefined));
     });
 
+    it("詳細取得中は詳細領域のローディングを表示すること", () => {
+        vi.mocked(protectedApiClient.get).mockImplementation((url: string) => {
+            if (url === "/resumes/resume-1") {
+                return new Promise(() => {});
+            }
+            return Promise.resolve(createAxiosResponse(undefined));
+        });
+
+        renderEditor();
+
+        expect(screen.getByRole("progressbar")).toBeVisible();
+        expect(screen.queryByRole("tab", { name: "基本" })).not.toBeInTheDocument();
+    });
+
     it("section tab切り替えで表示セクションとstoreを更新すること", async () => {
         const { user } = renderEditor();
 

--- a/frontend/src/features/resume/components/__tests__/resumeList.integration.test.tsx
+++ b/frontend/src/features/resume/components/__tests__/resumeList.integration.test.tsx
@@ -75,6 +75,8 @@ describe("resume list", () => {
 
         renderWithProviders(<ResumeListContainer />);
 
+        expect(screen.getByRole("progressbar")).toBeVisible();
+        expect(screen.getByPlaceholderText("職務経歴書名で検索...")).toBeInTheDocument();
         expect(screen.queryByText("表示するデータがありません。")).not.toBeInTheDocument();
 
         act(() => {

--- a/frontend/src/features/resume/components/backup/BackupContainer.tsx
+++ b/frontend/src/features/resume/components/backup/BackupContainer.tsx
@@ -1,4 +1,5 @@
 import { NoData } from "@/components/errors";
+import { Loading } from "@/components/ui";
 import { BackupSection, RestoreSection, useGetResumeList } from "@/features/resume";
 import { Box, Divider, Paper, Typography } from "@mui/material";
 
@@ -6,13 +7,15 @@ import { Box, Divider, Paper, Typography } from "@mui/material";
  * バックアップコンテナ
  */
 export const BackupContainer = () => {
-    const { data, isSuccess } = useGetResumeList();
+    const { data, isLoading, isSuccess } = useGetResumeList();
     const resumeList = data?.resumes ?? [];
 
     return (
         <Paper elevation={1} sx={{ p: 3 }}>
             {/* バックアップセクション */}
-            {!isSuccess ? null : resumeList.length > 0 ? (
+            {isLoading ? (
+                <Loading active variant="content" sx={{ minHeight: 160 }} />
+            ) : !isSuccess ? null : resumeList.length > 0 ? (
                 <BackupSection resumeList={resumeList} />
             ) : (
                 <Box>

--- a/frontend/src/features/resume/components/resume-list/ResumeListContainer.tsx
+++ b/frontend/src/features/resume/components/resume-list/ResumeListContainer.tsx
@@ -1,5 +1,5 @@
 import { NoData } from "@/components/errors";
-import { Button } from "@/components/ui";
+import { Button, Loading } from "@/components/ui";
 import { paths } from "@/config/paths";
 import { ResumeCard, SearchForm, useGetResumeList } from "@/features/resume";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
@@ -32,7 +32,7 @@ export const ResumeListContainer = () => {
     const [currentDisplayCount, setCurrentDisplayCount] = useState<number>(itemPerPage);
 
     // 職務経歴書一覧取得
-    const { data, isSuccess } = useGetResumeList();
+    const { data, isLoading, isSuccess } = useGetResumeList();
 
     // APIレスポンスから配列を取り出す
     const resumeData = data?.resumes ?? [];
@@ -97,7 +97,9 @@ export const ResumeListContainer = () => {
                 setSortType={setSortType}
             />
             {/* 職務経歴書カード */}
-            {!isSuccess ? null : filteredResumeData.length > 0 ? (
+            {isLoading ? (
+                <Loading active variant="content" sx={{ minHeight: "calc(100vh - 300px)" }} />
+            ) : !isSuccess ? null : filteredResumeData.length > 0 ? (
                 <Grid container spacing={3} sx={{ my: 4 }}>
                     {filteredResumeData.slice(0, currentDisplayCount).map((resume) => (
                         <Grid size={{ xs: 12, sm: 6, md: 4 }} key={resume.id}>

--- a/frontend/src/features/resume/components/resume/ResumeContainer.tsx
+++ b/frontend/src/features/resume/components/resume/ResumeContainer.tsx
@@ -1,5 +1,5 @@
 import { NotFound } from "@/components/errors";
-import { Button, Dialog } from "@/components/ui";
+import { Button, Dialog, Loading } from "@/components/ui";
 import {
     BottomMenu,
     buildPayloadForEntry,
@@ -390,9 +390,9 @@ export const ResumeContainer = () => {
         return <NotFound variant="content" />;
     }
 
-    // データ取得中またはresumeがnullの場合は何も表示しない
+    // データ取得中またはresumeがnullの場合は詳細領域内にローディングを表示する
     if (isLoading || !resume) {
-        return null;
+        return <Loading active variant="content" sx={{ minHeight: "calc(100vh - 240px)" }} />;
     }
 
     // 保存・削除ボタンの表示条件

--- a/frontend/src/providers/AppProvider.tsx
+++ b/frontend/src/providers/AppProvider.tsx
@@ -1,5 +1,4 @@
 import { ErrorBanner, ErrorFallback } from "@/components/errors";
-import { Loading } from "@/components/ui";
 import { env } from "@/config/env";
 import { darkTheme, lightTheme } from "@/config/theme";
 import { queryConfig } from "@/lib";
@@ -44,7 +43,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
                 <ErrorBoundary FallbackComponent={ErrorFallback}>
                     <QueryClientProvider client={queryClient}>
                         <NotificationProvider />
-                        <Loading />
                         <ErrorBanner />
                         {children}
                         <ReactQueryDevtools initialIsOpen={false} />

--- a/frontend/src/routes/AppRouter.tsx
+++ b/frontend/src/routes/AppRouter.tsx
@@ -1,8 +1,8 @@
 import { ErrorFallback, NotFound, ServerError } from "@/components/errors";
 import { ProtectedLayout, PublicLayout } from "@/components/layouts";
+import { Loading } from "@/components/ui";
 import { paths } from "@/config/paths";
 import { ProtectedLoader, PublicLoader } from "@/routes/AppLoader";
-import { Box, CircularProgress } from "@mui/material";
 import { lazy, Suspense } from "react";
 import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -31,11 +31,7 @@ const SettingUser = lazy(() => import("@/pages/SettingUser").then((module) => ({
 const Terms = lazy(() => import("@/pages/Terms").then((module) => ({ default: module.Terms })));
 const TwoFactor = lazy(() => import("@/pages/TwoFactor").then((module) => ({ default: module.TwoFactor })));
 
-const routeFallback = (
-    <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: 240 }}>
-        <CircularProgress size={40} />
-    </Box>
-);
+const routeFallback = <Loading active variant="content" />;
 
 /**
  * ルーティング

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,11 @@ interface ExtendedUserConfig extends UserConfig {
         deps: {
             interopDefault: boolean;
         };
+        server: {
+            deps: {
+                external: string[];
+            };
+        };
     };
 }
 
@@ -61,6 +66,11 @@ export default defineConfig({
         pool: "forks",
         deps: {
             interopDefault: true,
+        },
+        server: {
+            deps: {
+                external: ["axios-auth-refresh"],
+            },
         },
     },
 } as ExtendedUserConfig);


### PR DESCRIPTION
Changes:
共通Loadingをactive指定の領域内表示コンポーネントに変更し、AppProviderの全体Backdrop表示を削除。 職務経歴書一覧、詳細、バックアップ、Suspense fallbackのローディング表示を共通Loadingへ統一。 関連するintegration testを更新。

Reason:
ローディング中に画面全体がブロックされ、影響範囲外のUIまで操作できなくなる問題を解消するため。

BREAKING CHANGE: N/A
Related: N/A
Refs: #118